### PR TITLE
simplify strings extraction and provide mode for extracting static strings

### DIFF
--- a/floss/main.py
+++ b/floss/main.py
@@ -207,12 +207,12 @@ def extract_delta_bytes(delta, decoded_at_va, source_fva=0x0):
 
 def extract_strings(delta, min_length):
     ret = []
-    for s in strings.ascii_strings(delta.s):
+    for s in strings.extract_ascii_strings(delta.s):
         if s.s == "A" * len(s.s):
             # ignore strings of all "A", which is likely taint data
             continue
         ret.append(DecodedString(delta.va + s.offset, s.s, delta.decoded_at_va, delta.fva, delta.global_address))
-    for s in strings.unicode_strings(delta.s):
+    for s in strings.extract_unicode_strings(delta.s):
         if s.s == "A" * len(s.s):
             continue
         ret.append(DecodedString(delta.va + s.offset, s.s, delta.decoded_at_va, delta.fva, delta.global_address))

--- a/floss/main.py
+++ b/floss/main.py
@@ -14,12 +14,13 @@ import plugnplay
 import viv_utils
 import envi.memory
 
-from interfaces import DecodingRoutineIdentifier
+import strings
 import plugins.xor_plugin
 import plugins.library_function_plugin
 import plugins.function_meta_data_plugin
-from FunctionArgumentGetter import get_function_contexts
 from utils import makeEmulator
+from interfaces import DecodingRoutineIdentifier
+from FunctionArgumentGetter import get_function_contexts
 from DecodingManager import DecodedString, FunctionEmulator
 
 
@@ -204,12 +205,17 @@ def extract_delta_bytes(delta, decoded_at_va, source_fva=0x0):
     return delta_bytes
 
 
-def extract_strings(delta_bytes, min_length):
+def extract_strings(delta, min_length):
     ret = []
-    for s in strings.ascii_strings(delta_bytes.s):
-        ret.append(DecodedString(d.va + s.offset, s.s, d.decoded_at_va, d.fva, d.global_address))
-    for s in strings.unicode_strings(delta_bytes.s):
-        ret.append(DecodedString(d.va + s.offset, s.s, d.decoded_at_va, d.fva, d.global_address))
+    for s in strings.ascii_strings(delta.s):
+        if s.s == "A" * len(s.s):
+            # ignore strings of all "A", which is likely taint data
+            continue
+        ret.append(DecodedString(delta.va + s.offset, s.s, delta.decoded_at_va, delta.fva, delta.global_address))
+    for s in strings.unicode_strings(delta.s):
+        if s.s == "A" * len(s.s):
+            continue
+        ret.append(DecodedString(delta.va + s.offset, s.s, delta.decoded_at_va, delta.fva, delta.global_address))
     return ret
 
 

--- a/floss/strings.py
+++ b/floss/strings.py
@@ -1,0 +1,41 @@
+import re
+from collections import namedtuple
+
+
+ASCII_BYTE = " !\"#\$%&\'\(\)\*\+,-\./0123456789:;<=>\?@ABCDEFGHIJKLMNOPQRSTUVWXYZ\[\]\^_`abcdefghijklmnopqrstuvwxyz\{\|\}\\\~\t"
+
+
+String = namedtuple("String", ["s", "offset"])
+
+
+def ascii_strings(buf, n=4):
+    reg = "([%s]{%d,})" % (ASCII_BYTE, n)
+    ascii_re = re.compile(reg)
+    for match in ascii_re.finditer(buf):
+        yield String(match.group().decode("ascii"), match.start())
+
+def unicode_strings(buf, n=4):
+    reg = b"((?:[%s]\x00){%d,})" % (ASCII_BYTE, n)
+    ascii_re = re.compile(reg)
+    for match in ascii_re.finditer(buf):
+        try:
+            yield String(match.group().decode("utf-16"), match.start())
+        except UnicodeDecodeError:
+            pass
+
+
+def main():
+    import sys
+
+    with open(sys.argv[1], 'rb') as f:
+        b = f.read()
+
+    for s in ascii_strings(b, n=4):
+        print('0x{:x}: {:s}'.format(s.offset, s.s))
+
+    for s in unicode_strings(b):
+        print('0x{:x}: {:s}'.format(s.offset, s.s))
+
+
+if __name__ == '__main__':
+    main()

--- a/floss/strings.py
+++ b/floss/strings.py
@@ -8,13 +8,31 @@ ASCII_BYTE = " !\"#\$%&\'\(\)\*\+,-\./0123456789:;<=>\?@ABCDEFGHIJKLMNOPQRSTUVWX
 String = namedtuple("String", ["s", "offset"])
 
 
-def ascii_strings(buf, n=4):
+def extract_ascii_strings(buf, n=4):
+    '''
+    Extract ASCII strings from the given binary data.
+
+    :param buf: A bytestring.
+    :type buf: str
+    :param n: The minimum length of strings to extract.
+    :type n: int
+    :rtype: Sequence[String]
+    '''
     reg = "([%s]{%d,})" % (ASCII_BYTE, n)
     ascii_re = re.compile(reg)
     for match in ascii_re.finditer(buf):
         yield String(match.group().decode("ascii"), match.start())
 
-def unicode_strings(buf, n=4):
+def extract_unicode_strings(buf, n=4):
+    '''
+    Extract naive UTF-16 strings from the given binary data.
+
+    :param buf: A bytestring.
+    :type buf: str
+    :param n: The minimum length of strings to extract.
+    :type n: int
+    :rtype: Sequence[String]
+    '''
     reg = b"((?:[%s]\x00){%d,})" % (ASCII_BYTE, n)
     ascii_re = re.compile(reg)
     for match in ascii_re.finditer(buf):
@@ -30,10 +48,10 @@ def main():
     with open(sys.argv[1], 'rb') as f:
         b = f.read()
 
-    for s in ascii_strings(b, n=4):
+    for s in extract_ascii_strings(b):
         print('0x{:x}: {:s}'.format(s.offset, s.s))
 
-    for s in unicode_strings(b):
+    for s in extract_unicode_strings(b):
         print('0x{:x}: {:s}'.format(s.offset, s.s))
 
 


### PR DESCRIPTION
simplify the strings extraction routine to use the regex module rather than doing it manually. some manual testing demonstrates that the same strings are extracted, and performance remains the same (though i expect it would be better on a large dataset). the major benefit is that the code is much more readable, despite the use of regular expressions. string extraction moves to the file `strings.py`.

with this new set of routines, also add a mode to FLOSS that extracts ASCII and UTF-16 strings from the static binary bytes of the file. this is the `-a`/`--all_strings` flag. with this option, users now have little excuse to use `strings.exe` instead of FLOSS.