### PR TITLE
add quiet mode

### DIFF
--- a/floss/main.py
+++ b/floss/main.py
@@ -207,12 +207,12 @@ def extract_delta_bytes(delta, decoded_at_va, source_fva=0x0):
 
 def extract_strings(delta, min_length):
     ret = []
-    for s in strings.ascii_strings(delta.s):
+    for s in strings.extract_ascii_strings(delta.s):
         if s.s == "A" * len(s.s):
             # ignore strings of all "A", which is likely taint data
             continue
         ret.append(DecodedString(delta.va + s.offset, s.s, delta.decoded_at_va, delta.fva, delta.global_address))
-    for s in strings.unicode_strings(delta.s):
+    for s in strings.extract_unicode_strings(delta.s):
         if s.s == "A" * len(s.s):
             continue
         ret.append(DecodedString(delta.va + s.offset, s.s, delta.decoded_at_va, delta.fva, delta.global_address))

--- a/floss/main.py
+++ b/floss/main.py
@@ -14,12 +14,13 @@ import plugnplay
 import viv_utils
 import envi.memory
 
-from interfaces import DecodingRoutineIdentifier
+import strings
 import plugins.xor_plugin
 import plugins.library_function_plugin
 import plugins.function_meta_data_plugin
-from FunctionArgumentGetter import get_function_contexts
 from utils import makeEmulator
+from interfaces import DecodingRoutineIdentifier
+from FunctionArgumentGetter import get_function_contexts
 from DecodingManager import DecodedString, FunctionEmulator
 
 
@@ -204,12 +205,17 @@ def extract_delta_bytes(delta, decoded_at_va, source_fva=0x0):
     return delta_bytes
 
 
-def extract_strings(delta_bytes, min_length):
+def extract_strings(delta, min_length):
     ret = []
-    for s in strings.ascii_strings(delta_bytes.s):
-        ret.append(DecodedString(d.va + s.offset, s.s, d.decoded_at_va, d.fva, d.global_address))
-    for s in strings.unicode_strings(delta_bytes.s):
-        ret.append(DecodedString(d.va + s.offset, s.s, d.decoded_at_va, d.fva, d.global_address))
+    for s in strings.ascii_strings(delta.s):
+        if s.s == "A" * len(s.s):
+            # ignore strings of all "A", which is likely taint data
+            continue
+        ret.append(DecodedString(delta.va + s.offset, s.s, delta.decoded_at_va, delta.fva, delta.global_address))
+    for s in strings.unicode_strings(delta.s):
+        if s.s == "A" * len(s.s):
+            continue
+        ret.append(DecodedString(delta.va + s.offset, s.s, delta.decoded_at_va, delta.fva, delta.global_address))
     return ret
 
 

--- a/floss/strings.py
+++ b/floss/strings.py
@@ -1,0 +1,41 @@
+import re
+from collections import namedtuple
+
+
+ASCII_BYTE = " !\"#\$%&\'\(\)\*\+,-\./0123456789:;<=>\?@ABCDEFGHIJKLMNOPQRSTUVWXYZ\[\]\^_`abcdefghijklmnopqrstuvwxyz\{\|\}\\\~\t"
+
+
+String = namedtuple("String", ["s", "offset"])
+
+
+def ascii_strings(buf, n=4):
+    reg = "([%s]{%d,})" % (ASCII_BYTE, n)
+    ascii_re = re.compile(reg)
+    for match in ascii_re.finditer(buf):
+        yield String(match.group().decode("ascii"), match.start())
+
+def unicode_strings(buf, n=4):
+    reg = b"((?:[%s]\x00){%d,})" % (ASCII_BYTE, n)
+    ascii_re = re.compile(reg)
+    for match in ascii_re.finditer(buf):
+        try:
+            yield String(match.group().decode("utf-16"), match.start())
+        except UnicodeDecodeError:
+            pass
+
+
+def main():
+    import sys
+
+    with open(sys.argv[1], 'rb') as f:
+        b = f.read()
+
+    for s in ascii_strings(b, n=4):
+        print('0x{:x}: {:s}'.format(s.offset, s.s))
+
+    for s in unicode_strings(b):
+        print('0x{:x}: {:s}'.format(s.offset, s.s))
+
+
+if __name__ == '__main__':
+    main()

--- a/floss/strings.py
+++ b/floss/strings.py
@@ -8,13 +8,31 @@ ASCII_BYTE = " !\"#\$%&\'\(\)\*\+,-\./0123456789:;<=>\?@ABCDEFGHIJKLMNOPQRSTUVWX
 String = namedtuple("String", ["s", "offset"])
 
 
-def ascii_strings(buf, n=4):
+def extract_ascii_strings(buf, n=4):
+    '''
+    Extract ASCII strings from the given binary data.
+
+    :param buf: A bytestring.
+    :type buf: str
+    :param n: The minimum length of strings to extract.
+    :type n: int
+    :rtype: Sequence[String]
+    '''
     reg = "([%s]{%d,})" % (ASCII_BYTE, n)
     ascii_re = re.compile(reg)
     for match in ascii_re.finditer(buf):
         yield String(match.group().decode("ascii"), match.start())
 
-def unicode_strings(buf, n=4):
+def extract_unicode_strings(buf, n=4):
+    '''
+    Extract naive UTF-16 strings from the given binary data.
+
+    :param buf: A bytestring.
+    :type buf: str
+    :param n: The minimum length of strings to extract.
+    :type n: int
+    :rtype: Sequence[String]
+    '''
     reg = b"((?:[%s]\x00){%d,})" % (ASCII_BYTE, n)
     ascii_re = re.compile(reg)
     for match in ascii_re.finditer(buf):
@@ -30,10 +48,10 @@ def main():
     with open(sys.argv[1], 'rb') as f:
         b = f.read()
 
-    for s in ascii_strings(b, n=4):
+    for s in extract_ascii_strings(b):
         print('0x{:x}: {:s}'.format(s.offset, s.s))
 
-    for s in unicode_strings(b):
+    for s in extract_unicode_strings(b):
         print('0x{:x}: {:s}'.format(s.offset, s.s))
 
 


### PR DESCRIPTION
note: please accept #17 and #18 before reviewing this. this PR includes those patches.

add output mode that suppresses headers and formatting (such as offset) for strings. the output is only the strings identified (static or decoded). this means the output is appropriate to pipe directly into search/grep programs.

im not very happy with some of the output functions now, since theres all sorts of special handling. for example `output_strings`. in the inner loop, first check the length, then check the quiet mode, and then what? output formatting is often a messy of fragile, messy code. i think we're ok with min_length and quiet modes, but anything else, and we should think about some method of refactoring.