### PR TITLE
main: only extract decoded strings from PE files.

### DIFF
--- a/floss/main.py
+++ b/floss/main.py
@@ -560,6 +560,12 @@ def main():
 
     sample_file_path = parse_sample_file_path(parser, args)
 
+    with open(sample_file_path, "rb") as f:
+        magic = f.read(2)
+    if magic != "MZ":
+        floss_logger.error("FLOSS currently supports the following formats: PE")
+        return
+
     floss_logger.info("Generating vivisect workspace")
     vw = viv_utils.getWorkspace(sample_file_path)
 


### PR DESCRIPTION
checks if the input file appears to be a PE file by checking the magic MZ header.

during merge with #15, want this check to happen *after* extracting static strings. this is so the user can extract static strings from any binary file, but only decoded strings from PE files.

closes #14.