### PR TITLE
Testing architecture gap filling

### DIFF
--- a/tests/append_test_data.py
+++ b/tests/append_test_data.py
@@ -1,0 +1,131 @@
+"""
+Use this script to append data from the test.yml file to a sample.
+
+Dictionary format:
+{
+ "fva_string (0x%x)":["string1","string2",...]
+ <...>
+ optional: "all":["stringN",...]
+}
+
+Example:
+{
+ "0x401000":["hostid","SYSTEM"]
+ "all":["8.8.8.8","explorer.exe"]
+}
+"""""
+
+import os
+import sys
+import yaml
+import json
+import struct
+from pprint import pprint
+
+
+FILE_START = 0
+FILE_END = 2
+
+MAGIC = "FLSS"
+SIZE_OFFSET = 4
+SIZE_LEN = 4
+SIZE_MAGIC = len(MAGIC)
+
+
+def contains_magic(sample_path):
+    try:
+        f = open(sample_path, "rb")
+        f.seek((-SIZE_MAGIC), FILE_END)
+        m = f.read(SIZE_MAGIC)
+    except Exception as e:
+        print str(e)
+    finally:
+        f.close()
+    return m == MAGIC
+
+
+def read_test_dict_from_file(sample_path):
+    if not contains_magic(sample_path):
+        return None
+
+    test_dict = None
+    try:
+        f = open(sample_path, "rb")
+        f.seek((-(SIZE_MAGIC + SIZE_OFFSET + SIZE_LEN)), FILE_END)
+        test_dict_meta = f.read(SIZE_OFFSET + SIZE_LEN)
+        (data_offset, data_len) = struct.unpack("<II", test_dict_meta)
+        f.seek(data_offset, FILE_START)
+        test_dict_meta = f.read(data_len)
+        test_dict = json.loads(test_dict_meta)
+    except Exception as e:
+        print str(e)
+    finally:
+        f.close()
+
+    return test_dict
+
+
+def get_test_dict_from_yaml(yaml_file):
+    test_dict = {}
+    try:
+        f = open(yaml_file, "r")
+        spec = yaml.safe_load(f)
+        test_dict["all"] = spec["Decoded strings"]
+        # TODO add decoding function offsets
+    except Exception as e:
+        print str(e)
+        return test_dict
+    finally:
+        f.close()
+    return test_dict
+
+
+def append_test_dict_to_file(sample_path, test_dict):
+    json_data = json.dumps(test_dict)
+    data_len = len(json_data)
+    file_size = os.path.getsize(sample_path)
+    test_data = struct.pack("<II", file_size, data_len)
+    return append_data(sample_path, json_data + test_data + MAGIC)
+
+
+def append_data(sample_path, data):
+    try:
+        f = open(sample_path, "ab")
+        f.write(data)
+    except Exception as e:
+        print str(e)
+        return False
+    finally:
+        f.close()
+    return True
+
+
+def main():
+    if len(sys.argv) != 2:
+        print("Usage: %s <SAMPLE_PATH>" % sys.argv[0])
+        return -1
+
+    sample_path = sys.argv[1]
+    if not os.path.isfile(sample_path):
+        print("%s is not a file" % sample_path)
+        return
+
+    if contains_magic(sample_path):
+        print("%s already contains test data:" % sample_path)
+        pprint(read_test_dict_from_file(sample_path))
+        return
+
+    testdir = os.path.dirname(os.path.dirname(sample_path))
+    yaml_file = os.path.join(testdir, "test.yml")
+
+    test_dict = get_test_dict_from_yaml(yaml_file)
+
+    if test_dict:
+        print("Created test dictionary from %s:" % yaml_file)
+        pprint(test_dict)
+
+    if append_test_dict_to_file(sample_path, test_dict):
+        print("Successfully appended test data to %s" % sample_path)
+
+if __name__ == "__main__":
+    main()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,6 +3,48 @@ import os
 import yaml
 import pytest
 
+import viv_utils
+
+import floss.main as floss_main
+import floss.identification_manager as im
+import floss.stackstrings as stackstrings
+from append_test_data import read_test_dict_from_file
+
+
+def read_test_dict(sample_path):
+    """
+    Reads appended test dictionary from sample and returns "all" items for now.
+    Use tests/append_test_data.py to append test data from test.yml file to a sample.
+    """
+    test_dict = read_test_dict_from_file(sample_path)
+    if test_dict is None:
+        # sample does not contain test data
+        return []
+    else:
+        # TODO can extract decoding functions offsets from test_dict
+        return test_dict["all"]
+
+
+def extract_strings(sample_path):
+    """
+    Deobfuscate strings from sample_path
+    """
+    vw = viv_utils.getWorkspace(sample_path)
+    function_index = viv_utils.InstructionFunctionIndex(vw)
+    decoding_functions_candidates = identify_decoding_functions(vw)
+    decoded_strings = floss_main.decode_strings(vw, function_index, decoding_functions_candidates)
+    decoded_stackstrings = stackstrings.extract_stackstrings(vw)
+    decoded_strings.extend(decoded_stackstrings)
+    return [ds.s for ds in decoded_strings]
+
+
+def identify_decoding_functions(vw):
+    selected_functions = floss_main.select_functions(vw, None)
+    selected_plugin_names = floss_main.select_plugins(None)
+    selected_plugins = filter(lambda p: str(p) in selected_plugin_names, floss_main.get_all_plugins())
+    decoding_functions_candidates = im.identify_decoding_functions(vw, selected_plugins, selected_functions)
+    return decoding_functions_candidates
+
 
 def pytest_collect_file(parent, path):
     if path.basename == "test.yml":
@@ -15,14 +57,12 @@ class YamlFile(pytest.File):
         test_dir = os.path.dirname(str(self.fspath))
         for platform, archs in spec["Output Files"].items():
             for arch, filename in archs.items():
-                filepath = os.path.join(test_dir, filename)
-                if os.path.exists(filepath):
-                    yield FLOSSTest(self, platform, arch, filename, spec)
-
-
-def extract_strings(sample_path):
-    # TODO: implement me
-    return []
+                # TODO only test Windows PE files for now
+                _, fileext = os.path.splitext(filename)
+                if fileext == ".exe":
+                    filepath = os.path.join(test_dir, "bin", filename)
+                    if os.path.exists(filepath):
+                        yield FLOSSTest(self, platform, arch, os.path.join("bin", filename), spec)
 
 
 class FLOSSTest(pytest.Item):
@@ -42,11 +82,13 @@ class FLOSSTest(pytest.Item):
         test_dir = os.path.dirname(spec_path)
         test_path = os.path.join(test_dir, self.filename)
 
+        # TODO: alternatively, get test data from appended data:
+        # expected_strings = set(read_test_dict(test_path))
         expected_strings = set(self.spec["Decoded strings"])
         found_strings = set(extract_strings(test_path))
 
-        # TODO: enable this
-        # assert expected_strings < found_strings
+        # assert that expected_strings is not empty
+        assert expected_strings and (expected_strings <= found_strings)
 
     def reportinfo(self):
         return self.fspath, 0, "usecase: %s" % self.name

--- a/tests/src/decode-split-stackstrings/test.yml
+++ b/tests/src/decode-split-stackstrings/test.yml
@@ -5,8 +5,8 @@ Input buffer location: n/a
 Output buffer location: stack
 
 Decoded strings:
-    - hello world
-    - hello moon
+    - goodbye world
+    - goodbye moon
 
 Source files:
     - test-decode-split-stackstrings.c


### PR DESCRIPTION
Addresses the outstanding work from #69.
1. fix for decoded strings in decode-split-stackstrings test.yml
2. added script that appends the test data (decoded strings) from a test.yml file to a binary
3. run FLOSS and assert that deobfuscated strings have been found via conftest.py

Current limitations:
- Need to invoke tests from FLOSS main directory
- Only analyze Windows PE files (as FLOSS can't analyze ELF files currently, anyway)
- Might want to add decoding function offsets in test.yml file, although this might be infeasible due to chaning offsets, currently don't extract it from appended test data either
- Currently, gets expected strings from test.yml files instead of appended data

Example run output:
```
tests/src/decode-base64/test.yml::test-decode-base64::Windows::32bit PASSED
tests/src/decode-base64/test.yml::test-decode-base64::Windows::64bit FAILED
tests/src/decode-from-global/test.yml::test-decode-from-global::Windows::32bit PASSED
tests/src/decode-from-global/test.yml::test-decode-from-global::Windows::64bit PASSED
tests/src/decode-from-heap/test.yml::test-decode-from-heap::Windows::32bit FAILED
tests/src/decode-from-heap/test.yml::test-decode-from-heap::Windows::64bit FAILED
tests/src/decode-from-stack/test.yml::test-decode-from-stack::Windows::32bit PASSED
tests/src/decode-from-stack/test.yml::test-decode-from-stack::Windows::64bit PASSED
tests/src/decode-global-stackstrings/test.yml::test-decode-global-stackstrings::Windows::32bit FAILED
tests/src/decode-global-stackstrings/test.yml::test-decode-global-stackstrings::Windows::64bit FAILED
tests/src/decode-in-place/test.yml::test-decode-in-place::Windows::32bit PASSED
tests/src/decode-in-place/test.yml::test-decode-in-place::Windows::64bit PASSED
tests/src/decode-local-stackstrings/test.yml::test-decode-local-stackstrings::Windows::32bit PASSED
tests/src/decode-local-stackstrings/test.yml::test-decode-local-stackstrings::Windows::64bit PASSED
tests/src/decode-rc4/test.yml::test-decode-rc4::Windows::32bit FAILED
tests/src/decode-rc4/test.yml::test-decode-rc4::Windows::64bit FAILED
tests/src/decode-single-byte-xor/test.yml::test-decode-single-byte-xor::Windows::32bit PASSED
tests/src/decode-single-byte-xor/test.yml::test-decode-single-byte-xor::Windows::64bit PASSED
tests/src/decode-split-stackstrings/test.yml::test-decode-split-stackstrings::Windows::32bit PASSED
tests/src/decode-split-stackstrings/test.yml::test-decode-split-stackstrings::Windows::64bit PASSED
tests/src/decode-string-with-header/test.yml::test-decode-string-with-header::Windows::32bit FAILED
tests/src/decode-string-with-header/test.yml::test-decode-string-with-header::Windows::64bit FAILED
tests/src/decode-to-global/test.yml::test-decode-to-global::Windows::32bit PASSED
tests/src/decode-to-global/test.yml::test-decode-to-global::Windows::64bit PASSED
tests/src/decode-to-heap/test.yml::test-decode-to-heap::Windows::32bit PASSED
tests/src/decode-to-heap/test.yml::test-decode-to-heap::Windows::64bit PASSED
tests/src/decode-to-output-buf/test.yml::test-decode-to-output-buf::Windows::32bit PASSED
tests/src/decode-to-output-buf/test.yml::test-decode-to-output-buf::Windows::64bit PASSED
tests/src/decode-to-stack/test.yml::test-decode-to-stack::Windows::32bit PASSED
tests/src/decode-to-stack/test.yml::test-decode-to-stack::Windows::64bit PASSED
```