### PR TITLE
move footer code to its own module

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,6 +9,8 @@ except ImportError:
 
 
 requirements = [
+    "q",
+    "pyyaml",
     "tabulate",
     "vivisect",
     "plugnplay",

--- a/tests/append_test_data.py
+++ b/tests/append_test_data.py
@@ -32,7 +32,7 @@ SIZE_LEN = 4
 SIZE_MAGIC = len(MAGIC)
 
 
-def contains_magic(sample_path):
+def does_contain_magic_footer(sample_path):
     try:
         f = open(sample_path, "rb")
         f.seek((-SIZE_MAGIC), FILE_END)
@@ -45,7 +45,7 @@ def contains_magic(sample_path):
 
 
 def read_test_dict_from_file(sample_path):
-    if not contains_magic(sample_path):
+    if not does_contain_magic_footer(sample_path):
         return None
 
     test_dict = None
@@ -110,7 +110,7 @@ def main():
         print("%s is not a file" % sample_path)
         return
 
-    if contains_magic(sample_path):
+    if does_contain_magic_footer(sample_path):
         print("%s already contains test data:" % sample_path)
         pprint(read_test_dict_from_file(sample_path))
         return

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,24 +5,10 @@ import pytest
 
 import viv_utils
 
+import footer
 import floss.main as floss_main
 import floss.identification_manager as im
 import floss.stackstrings as stackstrings
-from append_test_data import read_test_dict_from_file
-
-
-def read_test_dict(sample_path):
-    """
-    Reads appended test dictionary from sample and returns "all" items for now.
-    Use tests/append_test_data.py to append test data from test.yml file to a sample.
-    """
-    test_dict = read_test_dict_from_file(sample_path)
-    if test_dict is None:
-        # sample does not contain test data
-        return []
-    else:
-        # TODO can extract decoding functions offsets from test_dict
-        return test_dict["all"]
 
 
 def extract_strings(sample_path):
@@ -58,7 +44,7 @@ class YamlFile(pytest.File):
         for platform, archs in spec["Output Files"].items():
             for arch, filename in archs.items():
                 filepath = os.path.join(test_dir, filename)
-                if os.path.exists(filepath):
+                if os.path.exists(filepath) and footer.has_footer(filepath):
                     yield FLOSSTest(self, platform, arch, filename, spec)
 
 
@@ -83,9 +69,7 @@ class FLOSSTest(pytest.Item):
         if not test_path.lower().endswith(".exe"):
             pytest.xfail("unsupported file format (known issue)")
 
-        # TODO: alternatively, get test data from appended data:
-        # expected_strings = set(read_test_dict(test_path))
-        expected_strings = set(self.spec["Decoded strings"])
+        expected_strings = set(footer.read_footer(test_path)["all"])
         found_strings = set(extract_strings(test_path))
 
         if expected_strings:

--- a/tests/footer.py
+++ b/tests/footer.py
@@ -1,0 +1,63 @@
+import json
+import struct
+import logging
+
+
+FILE_START = 0
+FILE_END = 2
+
+MAGIC = "FLSS"
+SIZE_OFFSET = 4
+SIZE_LEN = 4
+SIZE_MAGIC = len(MAGIC)
+
+
+logger = logging.getLogger(__name__)
+
+
+def has_footer(sample_path):
+    try:
+        with open(sample_path, "rb") as f:
+            f = open(sample_path, "rb")
+            f.seek((-SIZE_MAGIC), FILE_END)
+            return f.read(SIZE_MAGIC) == MAGIC
+    except Exception:
+        logger.warning("failed to check magic footer", exc_info=True)
+
+
+class NoFooterException(Exception):
+    pass
+
+
+def read_footer(sample_path):
+    if not has_footer(sample_path):
+        raise NoFooterException()
+
+    try:
+        with open(sample_path, "rb") as f:
+            f.seek((-(SIZE_MAGIC + SIZE_OFFSET + SIZE_LEN)), FILE_END)
+            test_dict_meta = f.read(SIZE_OFFSET + SIZE_LEN)
+            (data_offset, data_len) = struct.unpack("<II", test_dict_meta)
+            f.seek(data_offset, FILE_START)
+            test_dict_meta = f.read(data_len)
+            return json.loads(test_dict_meta)
+    except Exception as e:
+        logger.warning("failed to read footer", exc_info=True)
+
+
+class DuplicateFooterException(Exception):
+    pass
+
+
+def write_footer(sample_path, test_dict):
+    if has_footer(sample_path):
+        raise DuplicateFooterException()
+
+    json_data = json.dumps(test_dict)
+    data_len = len(json_data)
+    file_size = os.path.getsize(sample_path)
+    test_data = struct.pack("<II", file_size, data_len)
+    with open(sample_path, "ab") as f:
+        f.write(json_data + test_data + MAGIC)
+
+

--- a/tests/src/decode-base64/test.yml
+++ b/tests/src/decode-base64/test.yml
@@ -14,10 +14,10 @@ Source files:
 
 Output Files:
     Linux:
-        32bit: test-decode-base64
+        32bit: bin/test-decode-base64
     Windows:
-        32bit: test-decode-base64.exe
-        64bit: test-decode-base6464.exe
+        32bit: bin/test-decode-base64.exe
+        64bit: bin/test-decode-base6464.exe
 
 Build instructions (Windows): |
     cl.exe test-decode-base64.c base64.c /Fetest-decode-base64.exe

--- a/tests/src/decode-from-global/test.yml
+++ b/tests/src/decode-from-global/test.yml
@@ -12,10 +12,10 @@ Source files:
 
 Output Files:
     Linux:
-        32bit: test-decode-from-global
+        32bit: bin/test-decode-from-global
     Windows:
-        32bit: test-decode-from-global.exe
-        64bit: test-decode-from-global64.exe
+        32bit: bin/test-decode-from-global.exe
+        64bit: bin/test-decode-from-global64.exe
 
 Build instructions (Windows): |
     cl.exe test-decode-from-global.c /Fetest-decode-from-global.exe

--- a/tests/src/decode-from-heap/test.yml
+++ b/tests/src/decode-from-heap/test.yml
@@ -12,16 +12,16 @@ Source files:
 
 Output Files:
     Linux:
-        32bit: test-decode-from-heap
+        32bit: bin/test-decode-from-heap
     Windows:
-        32bit: test-decode-from-heap.exe
-        64bit: test-decode-from-heap64.exe
+        32bit: bin/test-decode-from-heap.exe
+        64bit: bin/test-decode-from-heap64.exe
 
 Build instructions (Windows): |
-      cl.exe test-decode-from-heap.c /Fetest-decode-from-heap.exe
+      cl.exe test-decode-from-heap.c /Febin/test-decode-from-heap.exe
 
 Build instructions (Linux): |
-      clang test-decode-from-heap.c -o test-decode-from-heap
+      clang test-decode-from-heap.c -o bin/test-decode-from-heap
 
 Build instructions (Cross compile for Windows on Linux): |
-      i686-w64-mingw32-clang test-decode-from-heap.c -o test-decode-from-heap.exe
+      i686-w64-mingw32-clang test-decode-from-heap.c -o bin/test-decode-from-heap.exe

--- a/tests/src/decode-from-stack/test.yml
+++ b/tests/src/decode-from-stack/test.yml
@@ -12,16 +12,16 @@ Source files:
 
 Output Files:
     Linux:
-        32bit: test-decode-from-stack
+        32bit: bin/test-decode-from-stack
     Windows:
-        32bit: test-decode-from-stack.exe
-        64bit: test-decode-from-stack64.exe
+        32bit: bin/test-decode-from-stack.exe
+        64bit: bin/test-decode-from-stack64.exe
 
 Build instructions (Windows): |
-    cl.exe test-decode-from-stack.c /Fetest-decode-from-stack.exe
+    cl.exe test-decode-from-stack.c /Febin/test-decode-from-stack.exe
 
 Build instructions (Linux): |
-    clang test-decode-from-stack.c -o test-decode-from-stack
+    clang test-decode-from-stack.c -o bin/test-decode-from-stack
 
 Build instructions (Cross compile for Windows on Linux): |
-    i686-w64-mingw32-clang test-decode-from-stack.c -o test-decode-from-stack.exe
+    i686-w64-mingw32-clang test-decode-from-stack.c -o bin/test-decode-from-stack.exe

--- a/tests/src/decode-global-stackstrings/test.yml
+++ b/tests/src/decode-global-stackstrings/test.yml
@@ -12,17 +12,17 @@ Source files:
 
 Output Files:
     Linux:
-        32bit: test-decode-global-stackstrings
+        32bit: bin/test-decode-global-stackstrings
     Windows:
-        32bit: test-decode-global-stackstrings.exe
-        64bit: test-decode-global-stackstrings64.exe
+        32bit: bin/test-decode-global-stackstrings.exe
+        64bit: bin/test-decode-global-stackstrings64.exe
 
 
 Build instructions (Windows): |
-    cl.exe test-decode-global-stackstrings.c /Fetest-decode-global-stackstrings.exe
+    cl.exe test-decode-global-stackstrings.c /Febin/test-decode-global-stackstrings.exe
 
 Build instructions (Linux): |
-    clang test-decode-global-stackstrings.c -o test-decode-global-stackstrings
+    clang test-decode-global-stackstrings.c -o bin/test-decode-global-stackstrings
 
 Build instructions (Cross compile for Windows on Linux): |
-    i686-w64-mingw32-clang test-decode-global-stackstrings.c -o test-decode-decode-stackstrings.exe
+    i686-w64-mingw32-clang test-decode-global-stackstrings.c -o bin/test-decode-decode-stackstrings.exe

--- a/tests/src/decode-in-place/test.yml
+++ b/tests/src/decode-in-place/test.yml
@@ -12,16 +12,16 @@ Source files:
 
 Output Files:
     Linux:
-        32bit: test-decode-in-place
+        32bit: bin/test-decode-in-place
     Windows:
-        32bit: test-decode-in-place.exe
-        64bit: test-decode-in-place64.exe
+        32bit: bin/test-decode-in-place.exe
+        64bit: bin/test-decode-in-place64.exe
 
 Build instructions (Windows): |
-    cl.exe test-decode-in-place.c /Fetest-decode-in-place.exe
+    cl.exe test-decode-in-place.c /Febin/test-decode-in-place.exe
 
 Build instructions (Linux): |
-    clang test-decode-in-place.c -o test-decode-in-place
+    clang test-decode-in-place.c -o bin/test-decode-in-place
 
 Build instructions (Cross compile for Windows on Linux): |
-    i686-w64-mingw32-clang test-decode-in-place.c -o test-decode-in-place.exe
+    i686-w64-mingw32-clang test-decode-in-place.c -o bin/test-decode-in-place.exe

--- a/tests/src/decode-local-stackstrings/test.yml
+++ b/tests/src/decode-local-stackstrings/test.yml
@@ -13,16 +13,16 @@ Source files:
 
 Output Files:
     Linux:
-        32bit: test-decode-local-stackstrings
+        32bit: bin/test-decode-local-stackstrings
     Windows:
-        32bit: test-decode-local-stackstrings.exe
-        64bit: test-decode-local-stackstrings64.exe
+        32bit: bin/test-decode-local-stackstrings.exe
+        64bit: bin/test-decode-local-stackstrings64.exe
 
 Build instructions (Windows): |
-    cl.exe test-decode-local-stackstrings.c /Fetest-decode-local-stackstrings.exe
+    cl.exe test-decode-local-stackstrings.c /Febin/test-decode-local-stackstrings.exe
 
 Build instructions (Linux): |
-    clang test-decode-local-stackstrings.c -o test-decode-local-stackstrings
+    clang test-decode-local-stackstrings.c -o bin/test-decode-local-stackstrings
 
 Build instructions (Cross compile for Windows on Linux): |
-    i686-w64-mingw32-clang++ test-decode-local-stackstrings.c -o test-decode-decode-stackstrings.exe
+    i686-w64-mingw32-clang++ test-decode-local-stackstrings.c -o bin/test-decode-decode-stackstrings.exe

--- a/tests/src/decode-rc4/test.yml
+++ b/tests/src/decode-rc4/test.yml
@@ -8,20 +8,20 @@ Decoded strings:
     - Hello world
 
 Source files:
-    - eg. test-decode-rc4.c
+    - test-decode-rc4.c
 
 Output Files:
     Linux:
-        32bit: test-decode-rc4
+        32bit: bin/test-decode-rc4
     Windows:
-        32bit: test-decode-rc4.exe
-        64bit: test-decode-rc464.exe
+        32bit: bin/test-decode-rc4.exe
+        64bit: bin/test-decode-rc464.exe
 
 Build instructions (Windows): |
-    cl.exe test-decode-rc4.c /Fetest-decode-rc4.exe
+    cl.exe test-decode-rc4.c /Febin/test-decode-rc4.exe
 
 Build instructions (Linux): |
-    clang test-decode-rc4.c -o test-decode-rc4
+    clang test-decode-rc4.c -o bin/test-decode-rc4
 
 Build instructions (Cross compile for Windows on Linux): |
-    i686-w64-mingw32-clang test-decode-rc4.c -o test-decode-rc4.exe
+    i686-w64-mingw32-clang test-decode-rc4.c -o bin/test-decode-rc4.exe

--- a/tests/src/decode-reencode-string/test.yml
+++ b/tests/src/decode-reencode-string/test.yml
@@ -12,19 +12,19 @@ Source files:
 
 Output Files:
     Linux:
-        32bit: eg. test-decode-reencode-string
+        32bit: bin/test-decode-reencode-string
     Windows:
-        32bit: eg. test-decode-reencode-string.exe
-        64bit: eg. test-decode-reencode-string64.exe
+        32bit: bin/test-decode-reencode-string.exe
+        64bit: bin/test-decode-reencode-string64.exe
 
 Build instructions (Windows): |
-    eg. rm test-decode-reencode-string.exe
-    eg. cl.exe test-decode-reencode-string.c /Fetest-decode-reencode-string.exe
+    rm test-decode-reencode-string.exe
+    cl.exe test-decode-reencode-string.c /Febin/test-decode-reencode-string.exe
 
 Build instructions (Linux): |
-    eg. rm test-decode-reencode-string
-    eg. clang test-decode-reencode-string.c -o test-decode-reencode-string
+    rm test-decode-reencode-string
+    clang test-decode-reencode-string.c -o bin/test-decode-reencode-string
 
 Build instructions (Cross compile for Windows on Linux): |
-    eg. rm test-decode-reencode-string.exe
-    eg. i686-w64-mingw32-clang test-decode-reencode-string.c -o test-decode-reencode-string.exe
+    rm test-decode-reencode-string.exe
+    i686-w64-mingw32-clang test-decode-reencode-string.c -o bin/test-decode-reencode-string.exe

--- a/tests/src/decode-single-byte-xor/test.yml
+++ b/tests/src/decode-single-byte-xor/test.yml
@@ -12,16 +12,16 @@ Source files:
 
 Output Files:
     Linux:
-        32bit: test-decode-single-byte-xor
+        32bit: bin/test-decode-single-byte-xor
     Windows:
-        32bit: test-decode-single-byte-xor.exe
-        64bit: test-decode-single-byte-xor64.exe
+        32bit: bin/test-decode-single-byte-xor.exe
+        64bit: bin/test-decode-single-byte-xor64.exe
 
 Build instructions (Windows): |
-    cl.exe test-decode-single-byte-xor.c /Fetest-decode-single-byte-xor.exe
+    cl.exe test-decode-single-byte-xor.c /Febin/test-decode-single-byte-xor.exe
 
 Build instructions (Linux): |
-    clang test-decode-single-byte-xor.c -o test-decode-single-byte-xor
+    clang test-decode-single-byte-xor.c -o bin/test-decode-single-byte-xor
 
 Build instructions (Cross compile for Windows on Linux): |
-    i686-w64-mingw32-clang test-decode-single-byte-xor.c -o test-decode-single-byte-xor.exe
+    i686-w64-mingw32-clang test-decode-single-byte-xor.c -o bin/test-decode-single-byte-xor.exe

--- a/tests/src/decode-split-stackstrings/test.yml
+++ b/tests/src/decode-split-stackstrings/test.yml
@@ -13,16 +13,16 @@ Source files:
 
 Output Files:
     Linux:
-        32bit: test-decode-split-stackstrings
+        32bit: bin/test-decode-split-stackstrings
     Windows:
-        32bit: test-decode-split-stackstrings.exe
-        64bit: test-decode-split-stackstrings64.exe
+        32bit: bin/test-decode-split-stackstrings.exe
+        64bit: bin/test-decode-split-stackstrings64.exe
 
 Build instructions (Windows): |
-    cl.exe test-decode-split-stackstrings.c /Fetest-decode-split-stackstrings.exe
+    cl.exe test-decode-split-stackstrings.c /Febin/test-decode-split-stackstrings.exe
 
 Build instructions (Linux): |
-    clang test-decode-split-stackstrings.c -o test-decode-split-stackstrings
+    clang test-decode-split-stackstrings.c -o bin/test-decode-split-stackstrings
 
 Build instructions (Cross compile for Windows on Linux): |
-    i686-w64-mingw32-clang++ test-decode-split-stackstrings.c -o test-decode-split-stackstrings.exe
+    i686-w64-mingw32-clang++ test-decode-split-stackstrings.c -o bin/test-decode-split-stackstrings.exe

--- a/tests/src/decode-string-by-index/test.yml
+++ b/tests/src/decode-string-by-index/test.yml
@@ -13,19 +13,19 @@ Source files:
 
 Output Files:
     Linux:
-        32bit: eg. test-decode-string-by-index
+        32bit: eg. bin/test-decode-string-by-index
     Windows:
-        32bit: eg. test-decode-string-by-index.exe
-        64bit: eg. test-decode-string-by-index64.exe
+        32bit: eg. bin/test-decode-string-by-index.exe
+        64bit: eg. bin/test-decode-string-by-index64.exe
 
 Build instructions (Windows): |
     eg. rm test-decode-string-by-index.exe
-    eg. cl.exe test-decode-string-by-index.c /Fetest-decode-string-by-index.exe
+    eg. cl.exe test-decode-string-by-index.c /Febin/test-decode-string-by-index.exe
 
 Build instructions (Linux): |
     eg. rm test-decode-string-by-index
-    eg. clang test-decode-string-by-index.c -o test-decode-string-by-index
+    eg. clang test-decode-string-by-index.c -o bin/test-decode-string-by-index
 
 Build instructions (Cross compile for Windows on Linux): |
     eg. rm test-decode-string-by-index.exe
-    eg. i686-w64-mingw32-clang test-decode-string-by-index.c -o test-decode-string-by-index.exe
+    eg. i686-w64-mingw32-clang test-decode-string-by-index.c -o bin/test-decode-string-by-index.exe

--- a/tests/src/decode-string-with-header/test.yml
+++ b/tests/src/decode-string-with-header/test.yml
@@ -8,20 +8,20 @@ Decoded strings:
     - Hello world
 
 Source files:
-    - eg. test-decode-string-with-header.c
+    - test-decode-string-with-header.c
 
 Output Files:
     Linux:
-        32bit: test-decode-string-with-header
+        32bit: bin/test-decode-string-with-header
     Windows:
-        32bit: test-decode-string-with-header.exe
-        64bit: test-decode-string-with-header64.exe
+        32bit: bin/test-decode-string-with-header.exe
+        64bit: bin/test-decode-string-with-header64.exe
 
 Build instructions (Windows): |
-    cl.exe test-decode-string-with-header.c /Fetest-decode-string-with-header.exe
+    cl.exe test-decode-string-with-header.c /Febin/test-decode-string-with-header.exe
 
 Build instructions (Linux): |
-    clang test-decode-string-with-header.c -o test-decode-string-with-header
+    clang test-decode-string-with-header.c -o bin/test-decode-string-with-header
 
 Build instructions (Cross compile for Windows on Linux): |
-    i686-w64-mingw32-clang test-decode-string-with-header.c -o test-decode-string-with-header.exe
+    i686-w64-mingw32-clang test-decode-string-with-header.c -o bin/test-decode-string-with-header.exe

--- a/tests/src/decode-to-global/test.yml
+++ b/tests/src/decode-to-global/test.yml
@@ -12,16 +12,16 @@ Source files:
 
 Output Files:
     Linux:
-        32bit: test-decode-to-global
+        32bit: bin/test-decode-to-global
     Windows:
-        32bit: test-decode-to-global.exe
-        64bit: test-decode-to-global64.exe
+        32bit: bin/test-decode-to-global.exe
+        64bit: bin/test-decode-to-global64.exe
 
 Build instructions (Windows): |
-    cl.exe test-decode-to-global.c /Fetest-decode-to-global.exe
+    cl.exe test-decode-to-global.c /Febin/test-decode-to-global.exe
 
 Build instructions (Linux): |
-    clang test-decode-to-global.c -o test-decode-to-global
+    clang test-decode-to-global.c -o bin/test-decode-to-global
 
 Build instructions (Cross compile for Windows on Linux): |
-    i686-w64-mingw32-clang test-decode-to-global.c -o test-decode-to-global.exe
+    i686-w64-mingw32-clang test-decode-to-global.c -o bin/test-decode-to-global.exe

--- a/tests/src/decode-to-heap/test.yml
+++ b/tests/src/decode-to-heap/test.yml
@@ -12,16 +12,16 @@ Source files:
 
 Output Files:
     Linux:
-        32bit: test-decode-to-heap
+        32bit: bin/test-decode-to-heap
     Windows:
-        32bit: test-decode-to-heap.exe
-        64bit: test-decode-to-heap64.exe
+        32bit: bin/test-decode-to-heap.exe
+        64bit: bin/test-decode-to-heap64.exe
 
 Build instructions (Windows): |
-    cl.exe test-decode-to-heap.c /Fetest-decode-to-heap.exe
+    cl.exe test-decode-to-heap.c /Febin/test-decode-to-heap.exe
 
 Build instructions (Linux): |
-    clang test-decode-to-heap.c -o test-decode-to-heap
+    clang test-decode-to-heap.c -o bin/test-decode-to-heap
 
 Build instructions (Cross compile for Windows on Linux): |
-    i686-w64-mingw32-clang test-decode-to-heap.c -o test-decode-to-heap.exe
+    i686-w64-mingw32-clang test-decode-to-heap.c -o bin/test-decode-to-heap.exe

--- a/tests/src/decode-to-output-buf/test.yml
+++ b/tests/src/decode-to-output-buf/test.yml
@@ -12,16 +12,16 @@ Source files:
 
 Output Files:
     Linux:
-        32bit: test-decode-to-output-buf
+        32bit: bin/test-decode-to-output-buf
     Windows:
-        32bit: test-decode-to-output-buf.exe
-        64bit: test-decode-to-output-buf64.exe
+        32bit: bin/test-decode-to-output-buf.exe
+        64bit: bin/test-decode-to-output-buf64.exe
 
 Build instructions (Windows): |
-    cl.exe test-decode-to-output-buf.c /Fetest-decode-to-output-buf.exe
+    cl.exe test-decode-to-output-buf.c /Febin/test-decode-to-output-buf.exe
 
 Build instructions (Linux): |
-    clang test-decode-to-output-buf.c -o test-decode-to-output-buf
+    clang test-decode-to-output-buf.c -o bin/test-decode-to-output-buf
 
 Build instructions (Cross compile for Windows on Linux): |
-    i686-w64-mingw32-clang test-decode-to-output-buf.c -o test-decode-to-output-buf.exe
+    i686-w64-mingw32-clang test-decode-to-output-buf.c -o bin/test-decode-to-output-buf.exe

--- a/tests/src/decode-to-stack/test.yml
+++ b/tests/src/decode-to-stack/test.yml
@@ -12,16 +12,16 @@ Source files:
 
 Output Files:
     Linux:
-        32bit: test-decode-to-stack
+        32bit: bin/test-decode-to-stack
     Windows:
-        32bit: test-decode-to-stack.exe
-        64bit: test-decode-to-stack64.exe
+        32bit: bin/test-decode-to-stack.exe
+        64bit: bin/test-decode-to-stack64.exe
 
 Build instructions (Windows): |
-    cl.exe test-decode-to-stack.c /Fetest-decode-to-stack.exe
+    cl.exe test-decode-to-stack.c /Febin/test-decode-to-stack.exe
 
 Build instructions (Linux): |
-    clang test-decode-to-stack.c -o test-decode-to-stack
+    clang test-decode-to-stack.c -o bin/test-decode-to-stack
 
 Build instructions (Cross compile for Windows on Linux): |
-    i686-w64-mingw32-clang test-decode-to-stack.c -o test-decode-to-stack.exe
+    i686-w64-mingw32-clang test-decode-to-stack.c -o bin/test-decode-to-stack.exe

--- a/tests/src/template/test.yml
+++ b/tests/src/template/test.yml
@@ -13,19 +13,19 @@ Source files:
 
 Output Files:
     Linux:
-        32bit: eg. template
+        32bit: eg. bin/template
     Windows:
-        32bit: eg. template.exe
-        64bit: eg. template64.exe
+        32bit: eg. bin/template.exe
+        64bit: eg. bin/template64.exe
 
 Build instructions (Windows): |
     eg. rm template.exe
-    eg. cl.exe template.c /Fetemplate.exe
+    eg. cl.exe template.c /Febin/template.exe
 
 Build instructions (Linux): |
     eg. rm template
-    eg. clang template.c -o template
+    eg. clang template.c -o bin/template
 
 Build instructions (Cross compile for Windows on Linux): |
     eg. rm template.exe
-    eg. i686-w64-mingw32-clang template.c -o template.exe
+    eg. i686-w64-mingw32-clang template.c -o bin/template.exe


### PR DESCRIPTION
note: review this after merging #87

moves get/set methods for sample test data ("footers") to their own module in `tests/`. makes it easy for different test scripts to access footers (like `conftest.py`).

unrelated: update `conftest.py` to pretty-format test failures. for example:

```
$ py.test tests/src/decode-base64/test.yml -v      
========== test session starts ==========
platform linux2 -- Python 2.7.6, pytest-2.9.1, py-1.4.31, pluggy-0.3.1 -- /home/user/env/bin/python2
cachedir: .cache
rootdir: /home/user/src/flare-floss, inifile: 
collected 3 items 

tests/src/decode-base64/test.yml::test-decode-base64::Windows::32bit PASSED
tests/src/decode-base64/test.yml::test-decode-base64::Windows::64bit FAILED
tests/src/decode-base64/test.yml::test-decode-base64::Linux::32bit xfail

========== FAILURES ==========
__________ usecase: test-decode-base64::Windows::64bit __________
FLOSS extraction failed:
   expected: set([u'hello world'])
   got: set([])
========== 1 failed, 1 passed, 1 xfailed in 7.39 seconds ==========
```