### PR TITLE
Feature/wb tests3

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -43,7 +43,8 @@ class YamlFile(pytest.File):
         for platform, archs in spec["Output Files"].items():
             for arch, filename in archs.items():
                 filepath = os.path.join(test_dir, filename)
-                if os.path.exists(filepath) and footer.has_footer(filepath):
+                if os.path.exists(filepath):
+                    #and footer.has_footer(filepath):
                     yield FLOSSTest(self, platform, arch, filename, spec)
 
 
@@ -74,7 +75,11 @@ class FLOSSTest(pytest.Item):
         if not test_path.lower().endswith(".exe"):
             pytest.xfail("unsupported file format (known issue)")
 
-        expected_strings = set(footer.read_footer(test_path)["all"])
+        if footer.has_footer(test_path):
+            expected_strings = set(footer.read_footer(test_path)["all"])
+        else:
+            expected_strings = set(self.spec["Decoded strings"])
+
         found_strings = set(extract_strings(test_path))
 
         if expected_strings:

--- a/tests/src/Makefile
+++ b/tests/src/Makefile
@@ -15,7 +15,8 @@ TESTS= \
 	decode-to-output-buf \
 	decode-to-stack \
 	decode-string-by-index \
-	decode-reencode-string
+	decode-reencode-string \
+	decode-wrapped-decoder
 
 
 clean:

--- a/tests/src/decode-wrapped-decoder/Makefile
+++ b/tests/src/decode-wrapped-decoder/Makefile
@@ -1,0 +1,30 @@
+NAME=test-decode-wrapped-decoder
+
+BUILDDIR=bin
+SRC=$(NAME).c
+LINUX=$(NAME)
+WINDOWS=$(NAME).exe
+WINDOWS64=$(NAME)64.exe
+
+dir=@mkdir -p $(@D)
+
+$(BUILDDIR)/$(LINUX): $(SRC)
+	$(dir)
+	clang $(SRC) -o $@
+
+
+$(BUILDDIR)/$(WINDOWS): $(SRC)
+	$(dir)
+	i686-w64-mingw32-clang $(SRC) -o $@
+
+
+$(BUILDDIR)/$(WINDOWS64): $(SRC)
+	$(dir)
+	x86_64-w64-mingw32-clang $(SRC) -o $@
+
+
+clean:
+	rm -rf $(BUILDDIR)/*~ $(BUILDDIR)/*.bak $(BUILDDIR)/*.exe $(BUILDDIR)/*.viv $(BUILDDIR)/*.swp $(BUILDDIR)/$(LINUX)
+
+
+all: $(BUILDDIR)/$(LINUX) $(BUILDDIR)/$(WINDOWS) $(BUILDDIR)/$(WINDOWS64)

--- a/tests/src/decode-wrapped-decoder/test-decode-wrapped-decoder.c
+++ b/tests/src/decode-wrapped-decoder/test-decode-wrapped-decoder.c
@@ -1,0 +1,37 @@
+#include <stdio.h>
+#include <string.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+
+int decode2(void *out_buf, size_t out_len, const void *in_buf, size_t in_len, unsigned char key) {
+    if (out_len != in_len) {
+        return -1;
+    }
+
+    for (unsigned int i = 0; i < out_len; i++) {
+        ((char *)out_buf)[i] = ((char *)in_buf)[i] ^ key;
+    }
+    if (out_len > 0) {
+        ((char *)out_buf)[out_len - 1] = 0;
+    }
+
+    return 0;
+}
+
+int decode(char *out_buf, size_t out_len, const char *in) {
+    return decode2(out_buf, out_len, in, strlen(in) + 1, 0x1);
+}
+
+
+int main(int argc, char **argv) {
+    char in[] = "idmmn!vnsme";
+    char out[12] = {0};
+
+    if (decode(out, sizeof(out), in)) {
+        perror("failed to decode.\n");
+        return -1;
+    }
+    printf("%s\n", out);
+    return 0;
+}

--- a/tests/src/decode-wrapped-decoder/test.yml
+++ b/tests/src/decode-wrapped-decoder/test.yml
@@ -1,0 +1,30 @@
+Test Name: test-decode-wrapped-decoder
+Test Purpose:  demonstrate detection and decoding of strings deobfuscated by routines with trivial wrappers.
+Decoding algorithm: single byte xor
+Input buffer location: stack
+Output buffer location: stack
+
+Decoded strings:
+    - hello world
+
+Source files:
+    - test-decode-wrapped-decoder.c
+
+Output Files:
+    Linux:
+        32bit: bin/test-decode-wrapped-decoder
+    Windows:
+        32bit: bin/test-decode-wrapped-decoder.exe
+        64bit: bin/test-decode-wrapped-decoder64.exe
+
+Build instructions (Windows): |
+    rm test-decode-wrapped-decoder.exe
+    cl.exe test-decode-wrapped-decoder.c /Febin/test-decode-wrapped-decoder.exe
+
+Build instructions (Linux): |
+    rm test-decode-wrapped-decoder
+    clang test-decode-wrapped-decoder.c -o bin/test-decode-wrapped-decoder
+
+Build instructions (Cross compile for Windows on Linux): |
+    rm test-decode-wrapped-decoder.exe
+    i686-w64-mingw32-clang test-decode-wrapped-decoder.c -o bin/test-decode-wrapped-decoder.exe


### PR DESCRIPTION
two things:

  - `conftest.py` pulls decoded strings from `test.yml` if there's no footer on the sample binary.
  - add test for "wrapped decoder functions"