### PR TITLE
conftest: pull xfail cases from test.yml

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -67,13 +67,16 @@ class FLOSSTest(pytest.Item):
         self.filename = filename
 
     def runtest(self):
+        xfail = self.spec.get("Xfail", {})
+        if "all" in xfail:
+            pytest.xfail("unsupported test case (known issue)")
+
+        if "{0.platform:s}-{0.arch:s}".format(self) in xfail:
+            pytest.xfail("unsupported platform&arch test case (known issue)")
+
         spec_path = self.location[0]
         test_dir = os.path.dirname(spec_path)
         test_path = os.path.join(test_dir, self.filename)
-
-        # TODO: add support for ELF, MACHO
-        if not test_path.lower().endswith(".exe"):
-            pytest.xfail("unsupported file format (known issue)")
 
         if footer.has_footer(test_path):
             expected_strings = set(footer.read_footer(test_path)["all"])

--- a/tests/src/decode-base64/test.yml
+++ b/tests/src/decode-base64/test.yml
@@ -27,3 +27,9 @@ Build instructions (Linux): |
 
 Build instructions (Cross compile for Windows on Linux): |
     i686-w64-mingw32-clang++ test-decode-base64.c base64.c -o test-decode-base64.exe
+
+Xfail:
+    - Windows-32bit
+    - Windows-64bit
+    - Linux-32bit
+

--- a/tests/src/decode-from-global/test.yml
+++ b/tests/src/decode-from-global/test.yml
@@ -25,3 +25,7 @@ Build instructions (Linux): |
 
 Build instructions (Cross compile for Windows on Linux): |
     i686-w64-mingw32-clang test-decode-from-global.c -o test-decode-from-global.exe
+
+Xfail:
+    - Linux-32bit
+

--- a/tests/src/decode-from-heap/test.yml
+++ b/tests/src/decode-from-heap/test.yml
@@ -25,3 +25,9 @@ Build instructions (Linux): |
 
 Build instructions (Cross compile for Windows on Linux): |
       i686-w64-mingw32-clang test-decode-from-heap.c -o bin/test-decode-from-heap.exe
+
+Xfail:
+    - Linux-32bit
+    - Windows-32bit
+    - Windows-64bit
+

--- a/tests/src/decode-from-stack/test.yml
+++ b/tests/src/decode-from-stack/test.yml
@@ -25,3 +25,7 @@ Build instructions (Linux): |
 
 Build instructions (Cross compile for Windows on Linux): |
     i686-w64-mingw32-clang test-decode-from-stack.c -o bin/test-decode-from-stack.exe
+
+Xfail:
+    - Linux-32bit
+

--- a/tests/src/decode-global-stackstrings/test.yml
+++ b/tests/src/decode-global-stackstrings/test.yml
@@ -26,3 +26,8 @@ Build instructions (Linux): |
 
 Build instructions (Cross compile for Windows on Linux): |
     i686-w64-mingw32-clang test-decode-global-stackstrings.c -o bin/test-decode-decode-stackstrings.exe
+
+Xfail:
+    - all
+    - Linux-32bit
+

--- a/tests/src/decode-in-place/test.yml
+++ b/tests/src/decode-in-place/test.yml
@@ -25,3 +25,7 @@ Build instructions (Linux): |
 
 Build instructions (Cross compile for Windows on Linux): |
     i686-w64-mingw32-clang test-decode-in-place.c -o bin/test-decode-in-place.exe
+
+Xfail:
+    - Linux-32bit
+

--- a/tests/src/decode-local-stackstrings/test.yml
+++ b/tests/src/decode-local-stackstrings/test.yml
@@ -26,3 +26,7 @@ Build instructions (Linux): |
 
 Build instructions (Cross compile for Windows on Linux): |
     i686-w64-mingw32-clang++ test-decode-local-stackstrings.c -o bin/test-decode-decode-stackstrings.exe
+
+Xfail:
+    - Linux-32bit
+

--- a/tests/src/decode-rc4/test.yml
+++ b/tests/src/decode-rc4/test.yml
@@ -25,3 +25,9 @@ Build instructions (Linux): |
 
 Build instructions (Cross compile for Windows on Linux): |
     i686-w64-mingw32-clang test-decode-rc4.c -o bin/test-decode-rc4.exe
+
+Xfail:
+    - Linux-32bit
+    - Windows-32bit
+    - Windows-64bit
+

--- a/tests/src/decode-reencode-string/test.yml
+++ b/tests/src/decode-reencode-string/test.yml
@@ -28,3 +28,9 @@ Build instructions (Linux): |
 Build instructions (Cross compile for Windows on Linux): |
     rm test-decode-reencode-string.exe
     i686-w64-mingw32-clang test-decode-reencode-string.c -o bin/test-decode-reencode-string.exe
+
+Xfail:
+    - Linux-32bit
+    - Windows-32bit
+    - Windows-64bit
+

--- a/tests/src/decode-single-byte-xor/test.yml
+++ b/tests/src/decode-single-byte-xor/test.yml
@@ -25,3 +25,7 @@ Build instructions (Linux): |
 
 Build instructions (Cross compile for Windows on Linux): |
     i686-w64-mingw32-clang test-decode-single-byte-xor.c -o bin/test-decode-single-byte-xor.exe
+
+Xfail:
+    - Linux-32bit
+

--- a/tests/src/decode-split-stackstrings/test.yml
+++ b/tests/src/decode-split-stackstrings/test.yml
@@ -26,3 +26,7 @@ Build instructions (Linux): |
 
 Build instructions (Cross compile for Windows on Linux): |
     i686-w64-mingw32-clang++ test-decode-split-stackstrings.c -o bin/test-decode-split-stackstrings.exe
+
+Xfail:
+    - Linux-32bit
+

--- a/tests/src/decode-string-by-index/test.yml
+++ b/tests/src/decode-string-by-index/test.yml
@@ -29,3 +29,7 @@ Build instructions (Linux): |
 Build instructions (Cross compile for Windows on Linux): |
     eg. rm test-decode-string-by-index.exe
     eg. i686-w64-mingw32-clang test-decode-string-by-index.c -o bin/test-decode-string-by-index.exe
+
+Xfail:
+    - Linux-32bit
+

--- a/tests/src/decode-string-with-header/test.yml
+++ b/tests/src/decode-string-with-header/test.yml
@@ -25,3 +25,9 @@ Build instructions (Linux): |
 
 Build instructions (Cross compile for Windows on Linux): |
     i686-w64-mingw32-clang test-decode-string-with-header.c -o bin/test-decode-string-with-header.exe
+
+Xfail:
+    - Linux-32bit
+    - Windows-32bit
+    - Windows-64bit
+

--- a/tests/src/decode-to-global/test.yml
+++ b/tests/src/decode-to-global/test.yml
@@ -25,3 +25,7 @@ Build instructions (Linux): |
 
 Build instructions (Cross compile for Windows on Linux): |
     i686-w64-mingw32-clang test-decode-to-global.c -o bin/test-decode-to-global.exe
+
+Xfail:
+    - Linux-32bit
+

--- a/tests/src/decode-to-heap/test.yml
+++ b/tests/src/decode-to-heap/test.yml
@@ -25,3 +25,7 @@ Build instructions (Linux): |
 
 Build instructions (Cross compile for Windows on Linux): |
     i686-w64-mingw32-clang test-decode-to-heap.c -o bin/test-decode-to-heap.exe
+
+Xfail:
+    - Linux-32bit
+

--- a/tests/src/decode-to-output-buf/test.yml
+++ b/tests/src/decode-to-output-buf/test.yml
@@ -25,3 +25,7 @@ Build instructions (Linux): |
 
 Build instructions (Cross compile for Windows on Linux): |
     i686-w64-mingw32-clang test-decode-to-output-buf.c -o bin/test-decode-to-output-buf.exe
+
+Xfail:
+    - Linux-32bit
+

--- a/tests/src/decode-to-stack/test.yml
+++ b/tests/src/decode-to-stack/test.yml
@@ -25,3 +25,7 @@ Build instructions (Linux): |
 
 Build instructions (Cross compile for Windows on Linux): |
     i686-w64-mingw32-clang test-decode-to-stack.c -o bin/test-decode-to-stack.exe
+
+Xfail:
+    - Linux-32bit
+

--- a/tests/src/decode-wrapped-decoder/test.yml
+++ b/tests/src/decode-wrapped-decoder/test.yml
@@ -28,3 +28,8 @@ Build instructions (Linux): |
 Build instructions (Cross compile for Windows on Linux): |
     rm test-decode-wrapped-decoder.exe
     i686-w64-mingw32-clang test-decode-wrapped-decoder.c -o bin/test-decode-wrapped-decoder.exe
+
+Xfail:
+    - all
+    - Linux-32bit
+

--- a/tests/src/template/test.yml
+++ b/tests/src/template/test.yml
@@ -29,3 +29,7 @@ Build instructions (Linux): |
 Build instructions (Cross compile for Windows on Linux): |
     eg. rm template.exe
     eg. i686-w64-mingw32-clang template.c -o bin/template.exe
+
+Xfail:
+    - Linux-32bit
+


### PR DESCRIPTION
closes #76.

note: travis should have no failures (only xfail and success), or this PR should not be accepted.