### PR TITLE
Refactor hooks, add a few new ones

### DIFF
--- a/floss/api_hooks.py
+++ b/floss/api_hooks.py
@@ -1,0 +1,301 @@
+import contextlib
+
+import envi
+import viv_utils
+
+
+class ApiMonitor(viv_utils.emulator_drivers.Monitor):
+    '''
+    The ApiMonitor observes emulation and cleans up API function returns.
+    '''
+    def __init__(self, vw, function_index):
+        viv_utils.emulator_drivers.Monitor.__init__(self, vw)
+        self.function_index = function_index
+        self.bps = set([])
+
+    def apicall(self, emu, op, pc, api, argv):
+        # overridden from Monitor
+        self.d("apicall: %s %s %s %s %s", emu, op, pc, api, argv)
+
+    def prehook(self, emu, op, startpc):
+        # overridden from Monitor
+
+        # to assist with debugging
+        # add an address to this object, and you'll drop into an interactive shell
+        bps = self.bps
+        #bps.add(0x401560)
+        if startpc in bps:
+            self.dumpState(emu)
+            from hexdump import hexdump
+            from IPython import embed; embed()
+
+        #self.d("%s: %s", hex(startpc), op)
+
+    def posthook(self, emu, op, endpc):
+        # overridden from Monitor
+        if op.mnem == "ret":
+            try:
+                self._check_return(emu, op)
+            except Exception as e:
+                self.d(str(e))
+
+    def _check_return(self, emu, op):
+        '''
+        Ensure that the target of the return is within the allowed set of functions.
+        Do nothing, if return address is valid. If return address is invalid:
+        _fix_return modifies program counter and stack pointer if a valid return address is found
+        on the stack or raises an Exception if no valid return address is found.
+        '''
+        function_start = self.function_index[op.va]
+        return_addresses = self._get_return_vas(emu, function_start)
+
+        if op.opers:
+            # adjust stack in case of `ret imm16` instruction
+            emu.setStackCounter(emu.getStackCounter() - op.opers[0].imm)
+
+        return_address = self.getStackValue(emu, -4)
+        if return_address not in return_addresses:
+            self._logger.debug("Return address 0x%08X is invalid", return_address)
+            self._fix_return(emu, return_address, return_addresses)
+            # TODO return, handle Exception
+        else:
+            self._logger.debug("Return address 0x%08X is valid, returning", return_address)
+            # TODO return?
+
+    def _get_return_vas(self, emu, function_start):
+        '''
+        Get the list of valid addresses to which a function should return.
+        '''
+        return_vas = []
+        callers = self._vw.getCallers(function_start)
+        for caller in callers:
+            call_op = emu.parseOpcode(caller)
+            return_va = call_op.va + call_op.size
+            return_vas.append(return_va)
+        return return_vas
+
+    def _fix_return(self, emu, return_address, return_addresses):
+        '''
+        Find a valid return address from return_addresses on the stack. Adjust the stack accordingly
+        or raise an Exception if no valid address is found within the search boundaries.
+        Modify program counter and stack pointer, so the emulator does not return to a garbage address.
+        '''
+        self.dumpStack(emu)
+        NUM_ADDRESSES = 4
+        pointer_size = emu.getPointerSize()
+        STACK_SEARCH_WINDOW = pointer_size * NUM_ADDRESSES
+        esp = emu.getStackCounter()
+        for offset in xrange(0, STACK_SEARCH_WINDOW, pointer_size):
+            ret_va_candidate = self.getStackValue(emu, offset)
+            if ret_va_candidate in return_addresses:
+                emu.setProgramCounter(ret_va_candidate)
+                emu.setStackCounter(esp + offset + pointer_size)
+                self._logger.debug("Returning to 0x%08X, adjusted stack:", ret_va_candidate)
+                self.dumpStack(emu)
+                return
+
+        self.dumpStack(emu)
+        raise Exception("No valid return address found...")
+
+    def dumpStack(self, emu):
+        '''
+        Convenience debugging routine for showing
+         state current state of the stack.
+        '''
+        esp = emu.getStackCounter()
+        stack_str = ""
+        for i in xrange(16, -16, -4):
+            if i == 0:
+                sp = "<= SP"
+            else:
+                sp = "%02x" % (-i)
+            stack_str = "%s\n0x%08x - 0x%08x %s" % (stack_str, (esp - i), self.getStackValue(emu, -i), sp)
+        self.i(stack_str)
+
+    def dumpState(self, emu):
+        self.i("eip: 0x%x", emu.getRegisterByName("eip"))
+        self.i("esp: 0x%x", emu.getRegisterByName("esp"))
+        self.i("eax: 0x%x", emu.getRegisterByName("eax"))
+        self.i("ebx: 0x%x", emu.getRegisterByName("ebx"))
+        self.i("ecx: 0x%x", emu.getRegisterByName("ecx"))
+        self.i("edx: 0x%x", emu.getRegisterByName("edx"))
+
+        self.dumpStack(emu)
+
+
+def pointerSize(emu):
+    '''
+    Convenience method whose name might be more readable
+     than fetching emu.imem_psize.
+    Returns the size of a pointer in bytes for the given emulator.
+    :rtype: int
+    '''
+    return emu.imem_psize
+
+
+def popStack(emu):
+    '''
+    Remove the element at the top of the stack.
+    :rtype: int
+    '''
+    v = emu.readMemoryFormat(emu.getStackCounter(), "<P")[0]
+    emu.setStackCounter(emu.getStackCounter() + pointerSize(emu))
+    return v
+
+
+class GetProcessHeapHook(viv_utils.emulator_drivers.Hook):
+    '''
+    Hook and handle calls to GetProcessHeap, returning 0.
+    '''
+    def hook(self, callname, emu, callconv, api, argv):
+        if callname == "kernel32.GetProcessHeap":
+            # nop
+            callconv.execCallReturn(emu, 0, len(argv))
+            return True
+        raise viv_utils.emulator_drivers.UnsupportedFunction()
+
+
+def round(i, size):
+    '''
+    Round `i` to the nearest greater-or-equal-to multiple of `size`.
+
+    :type i: int
+    :type size: int
+    :rtype: int
+    '''
+    if i % size == 0:
+        return i
+    return i + (i - (i % size))
+
+
+class RtlAllocateHeapHook(viv_utils.emulator_drivers.Hook):
+    '''
+    Hook calls to RtlAllocateHeap, allocate memory in a "heap"
+     section, and return pointers to this memory.
+    The base heap address is 0x69690000.
+    The max allocation size is 10 MB.
+    '''
+    def __init__(self, *args, **kwargs):
+        super(RtlAllocateHeapHook, self).__init__(*args, **kwargs)
+        self._heap_addr = 0x69690000
+
+    MAX_ALLOCATION_SIZE = 10 * 1024 * 1024
+
+    def _allocate_mem(self, emu, size):
+        size = round(size, 0x1000)
+        if size > self.MAX_ALLOCATION_SIZE:
+            size = self.MAX_ALLOCATION_SIZE
+        va = self._heap_addr
+        self.d("RtlAllocateHeap: mapping %s bytes at %s", hex(size), hex(va))
+        emu.addMemoryMap(va, envi.memory.MM_RWX, "[heap allocation]", "\x00" * (size + 4))
+        emu.writeMemory(va, "\x00" * size)
+        self._heap_addr += size
+        return va
+
+    def hook(self, callname, driver, callconv, api, argv):
+        # works for kernel32.HeapAlloc
+        if callname == "ntdll.RtlAllocateHeap":
+            emu = driver
+            size = driver.getStackValue(0xC)
+            va = self._allocate_mem(emu, size)
+            callconv.execCallReturn(emu, va, len(argv))
+            return True
+        raise viv_utils.emulator_drivers.UnsupportedFunction()
+
+
+class AllocateHeap(RtlAllocateHeapHook):
+    '''
+    Hook calls to AllocateHeap and handle them like calls to RtlAllocateHeapHook.
+    '''
+    def __init__(self, *args, **kwargs):
+        super(AllocateHeap, self).__init__(*args, **kwargs)
+
+    def hook(self, callname, driver, callconv, api, argv):
+        if callname == "kernel32.LocalAlloc" or \
+           callname == "kernel32.GlobalAlloc" or \
+           callname == "kernel32.VirtualAlloc":
+            emu = driver
+            # TODO dependant on calling convention, see issue #124
+            size = driver.getStackValue(0x8)
+            va = self._allocate_mem(emu, size)
+            callconv.execCallReturn(emu, va, len(argv))
+            return True
+        raise viv_utils.emulator_drivers.UnsupportedFunction()
+
+
+class MallocHeap(RtlAllocateHeapHook):
+    '''
+    Hook calls to malloc and handle them like calls to RtlAllocateHeapHook.
+    '''
+    def __init__(self, *args, **kwargs):
+        super(MallocHeap, self).__init__(*args, **kwargs)
+
+    def hook(self, callname, driver, callconv, api, argv):
+        if callname == "msvcrt.malloc":
+            emu = driver
+            size = driver.getStackValue(0x4)
+            va = self._allocate_mem(emu, 0x100)  # TODO hard-coded!
+            callconv.execCallReturn(emu, va, len(argv))
+            return True
+        raise viv_utils.emulator_drivers.UnsupportedFunction()
+
+
+class MemcpyHook(viv_utils.emulator_drivers.Hook):
+    '''
+    Hook and handle calls to memcpy.
+    '''
+    def __init__(self, *args, **kwargs):
+        super(MemcpyHook, self).__init__(*args, **kwargs)
+
+    def hook(self, callname, driver, callconv, api, argv):
+        if callname == "msvcrt.memcpy":
+            emu = driver
+            dst, src, count = argv
+            data = emu.readMemory(src, count)
+            emu.writeMemory(dst, data)
+            callconv.execCallReturn(emu, 0x0, len(argv))
+            return True
+
+        raise viv_utils.emulator_drivers.UnsupportedFunction()
+
+
+class ExitProcessHook(viv_utils.emulator_drivers.Hook):
+    '''
+    Hook calls to ExitProcess and stop emulation when these are hit.
+    '''
+    def __init__(self, *args, **kwargs):
+        super(ExitProcessHook, self).__init__(*args, **kwargs)
+
+    def hook(self, callname, driver, callconv, api, argv):
+        if callname == "kernel32.ExitProcess":
+            raise viv_utils.emulator_drivers.StopEmulation()
+
+
+DEFAULT_HOOKS = [
+    GetProcessHeapHook(),
+    RtlAllocateHeapHook(),
+    AllocateHeap(),
+    MallocHeap(),
+    ExitProcessHook(),
+    MemcpyHook(),
+]
+
+
+@contextlib.contextmanager
+def defaultHooks(driver):
+    '''
+    Install and remove the default set of hooks to handle common functions.
+
+    intended usage:
+
+        with defaultHooks(driver):
+            driver.runFunction()
+            ...
+    '''
+    try:
+        for hook in DEFAULT_HOOKS:
+            driver.add_hook(hook)
+        yield
+    finally:
+        for hook in DEFAULT_HOOKS:
+            driver.remove_hook(hook)

--- a/floss/api_hooks.py
+++ b/floss/api_hooks.py
@@ -231,7 +231,8 @@ class MallocHeap(RtlAllocateHeapHook):
         super(MallocHeap, self).__init__(*args, **kwargs)
 
     def hook(self, callname, driver, callconv, api, argv):
-        if callname == "msvcrt.malloc":
+        if callname == "msvcrt.malloc" or \
+           callname == "msvcrt.calloc":
             emu = driver
             size = driver.getStackValue(0x4)
             va = self._allocate_mem(emu, 0x100)  # TODO hard-coded!

--- a/floss/decoding_manager.py
+++ b/floss/decoding_manager.py
@@ -1,10 +1,12 @@
 import logging
 from collections import namedtuple
 
-from enum import Enum
 import viv_utils
 import viv_utils.emulator_drivers
 import envi.memory
+from enum import Enum
+
+import api_hooks
 
 
 floss_logger = logging.getLogger("floss")
@@ -20,234 +22,6 @@ class LocationType(Enum):
     STACK = 1
     GLOBAL = 2
     HEAP = 3
-
-
-class ApiMonitor(viv_utils.emulator_drivers.Monitor):
-    '''
-    The ApiMonitor observes emulation and provides an interface
-     for hooking API calls.
-    '''
-    def __init__(self, vw, function_index):
-        viv_utils.emulator_drivers.Monitor.__init__(self, vw)
-        self.function_index = function_index
-
-    def apicall(self, emu, op, pc, api, argv):
-        # overridden from Monitor
-        self.d("apicall: %s %s %s %s %s", emu, op, pc, api, argv)
-
-    def prehook(self, emu, op, startpc):
-        # overridden from Monitor
-        self.d("%s: %s", hex(startpc), op)
-
-    def posthook(self, emu, op, endpc):
-        # overridden from Monitor
-        if op.mnem == "ret":
-            try:
-                self._check_return(emu, op)
-            except Exception as e:
-                self.d(str(e))
-
-    def _check_return(self, emu, op):
-        '''
-        Ensure that the target of the return is within the allowed set of functions.
-        Do nothing, if return address is valid. If return address is invalid:
-        _fix_return modifies program counter and stack pointer if a valid return address is found
-        on the stack or raises an Exception if no valid return address is found.
-        '''
-        function_start = self.function_index[op.va]
-        return_addresses = self._get_return_vas(emu, function_start)
-
-        if op.opers:
-            # adjust stack in case of `ret imm16` instruction
-            emu.setStackCounter(emu.getStackCounter() - op.opers[0].imm)
-
-        return_address = self.getStackValue(emu, -4)
-        if return_address not in return_addresses:
-            self._logger.debug("Return address 0x%08X is invalid", return_address)
-            self._fix_return(emu, return_address, return_addresses)
-            # TODO return, handle Exception
-        else:
-            self._logger.debug("Return address 0x%08X is valid, returning", return_address)
-            # TODO return?
-
-    def _get_return_vas(self, emu, function_start):
-        '''
-        Get the list of valid addresses to which a function should return.
-        '''
-        return_vas = []
-        callers = self._vw.getCallers(function_start)
-        for caller in callers:
-            call_op = emu.parseOpcode(caller)
-            return_va = call_op.va + call_op.size
-            return_vas.append(return_va)
-        return return_vas
-
-    def _fix_return(self, emu, return_address, return_addresses):
-        '''
-        Find a valid return address from return_addresses on the stack. Adjust the stack accordingly
-        or raise an Exception if no valid address is found within the search boundaries.
-        Modify program counter and stack pointer, so the emulator does not return to a garbage address.
-        '''
-        self.dumpStack(emu)
-        NUM_ADDRESSES = 4
-        pointer_size = emu.getPointerSize()
-        STACK_SEARCH_WINDOW = pointer_size * NUM_ADDRESSES
-        esp = emu.getStackCounter()
-        for offset in xrange(0, STACK_SEARCH_WINDOW, pointer_size):
-            ret_va_candidate = self.getStackValue(emu, offset)
-            if ret_va_candidate in return_addresses:
-                emu.setProgramCounter(ret_va_candidate)
-                emu.setStackCounter(esp + offset + pointer_size)
-                self._logger.debug("Returning to 0x%08X, adjusted stack:", ret_va_candidate)
-                self.dumpStack(emu)
-                return
-
-        self.dumpStack(emu)
-        raise Exception("No valid return address found...")
-
-    def dumpStack(self, emu):
-        '''
-        Convenience debugging routine for showing
-         state current state of the stack.
-        '''
-        esp = emu.getStackCounter()
-        stack_str = ""
-        for i in xrange(16, -16, -4):
-            if i == 0:
-                sp = "<= SP"
-            else:
-                sp = "%02d" % i
-            stack_str = "%s\n0x%08X - 0x%08X %s" % (stack_str, (esp + i), self.getStackValue(emu, i), sp)
-        self._logger.debug(stack_str)
-
-
-def pointerSize(emu):
-    '''
-    Convenience method whose name might be more readable
-     than fetching emu.imem_psize.
-    Returns the size of a pointer in bytes for the given emulator.
-    :rtype: int
-    '''
-    return emu.imem_psize
-
-
-def popStack(emu):
-    '''
-    Remove the element at the top of the stack.
-    :rtype: int
-    '''
-    v = emu.readMemoryFormat(emu.getStackCounter(), "<P")[0]
-    emu.setStackCounter(emu.getStackCounter() + pointerSize(emu))
-    return v
-
-
-class GetProcessHeapHook(viv_utils.emulator_drivers.Hook):
-    '''
-    Hook and handle calls to GetProcessHeap, returning 0.
-    '''
-    def hook(self, callname, emu, callconv, api, argv):
-        if callname == "kernel32.GetProcessHeap":
-            # nop
-            callconv.execCallReturn(emu, 0, len(argv))
-            return True
-        raise viv_utils.emulator_drivers.UnsupportedFunction()
-
-
-def round(i, size):
-    '''
-    Round `i` to the nearest greater-or-equal-to multiple of `size`.
-
-    :type i: int
-    :type size: int
-    :rtype: int
-    '''
-    if i % size == 0:
-        return i
-    return i + (i - (i % size))
-
-
-class RtlAllocateHeapHook(viv_utils.emulator_drivers.Hook):
-    '''
-    Hook calls to RtlAllocateHeap, allocate memory in a "heap"
-     section, and return pointers to this memory.
-    The base heap address is 0x69690000.
-    The max allocation size is 10 MB.
-    '''
-    def __init__(self, *args, **kwargs):
-        super(RtlAllocateHeapHook, self).__init__(*args, **kwargs)
-        self._heap_addr = 0x69690000
-
-    MAX_ALLOCATION_SIZE = 10 * 1024 * 1024
-
-    def _allocate_mem(self, emu, size):
-        size = round(size, 0x1000)
-        if size > self.MAX_ALLOCATION_SIZE:
-            size = self.MAX_ALLOCATION_SIZE
-        va = self._heap_addr
-        self.d("RtlAllocateHeap: mapping %s bytes at %s", hex(size), hex(va))
-        emu.addMemoryMap(va, envi.memory.MM_RWX, "[heap allocation]", "\x00" * (size + 4))
-        emu.writeMemory(va, "\x00" * size)
-        self._heap_addr += size
-        return va
-
-    def hook(self, callname, driver, callconv, api, argv):
-        # works for kernel32.HeapAlloc
-        if callname == "ntdll.RtlAllocateHeap":
-            emu = driver
-            size = driver.getStackValue(0xC)
-            va = self._allocate_mem(emu, size)
-            callconv.execCallReturn(emu, va, len(argv))
-            return True
-        raise viv_utils.emulator_drivers.UnsupportedFunction()
-
-
-class AllocateHeap(RtlAllocateHeapHook):
-    '''
-    Hook calls to AllocateHeap and handle them like calls to RtlAllocateHeapHook.
-    '''
-    def __init__(self, *args, **kwargs):
-        super(AllocateHeap, self).__init__(*args, **kwargs)
-
-    def hook(self, callname, driver, callconv, api, argv):
-        if callname == "kernel32.LocalAlloc" or \
-           callname == "kernel32.GlobalAlloc" or \
-           callname == "kernel32.VirtualAlloc":
-            emu = driver
-            # TODO dependant on calling convention, see issue #124
-            size = driver.getStackValue(0x8)
-            va = self._allocate_mem(emu, size)
-            callconv.execCallReturn(emu, va, len(argv))
-            return True
-        raise viv_utils.emulator_drivers.UnsupportedFunction()
-
-
-class MallocHeap(RtlAllocateHeapHook):
-    '''
-    Hook calls to malloc and handle them like calls to RtlAllocateHeapHook.
-    '''
-    def __init__(self, *args, **kwargs):
-        super(MallocHeap, self).__init__(*args, **kwargs)
-
-    def hook(self, callname, driver, callconv, api, argv):
-        if callname == "msvcrt.malloc":
-            emu = driver
-            size = driver.getStackValue(0x4)
-            va = self._allocate_mem(emu, 0x100)  # TODO hard-coded!
-            callconv.execCallReturn(emu, va, len(argv))
-            return True
-        raise viv_utils.emulator_drivers.UnsupportedFunction()
-
-
-class ExitProcessHook(viv_utils.emulator_drivers.Hook):
-    '''
-    Hook calls to ExitProcess and stop emulation when these are hit.
-    '''
-    def __init__(self, *args, **kwargs):
-        super(ExitProcessHook, self).__init__(*args, **kwargs)
-
-    def hook(self, callname, driver, callconv, api, argv):
-        if callname == "kernel32.ExitProcess":
-            raise viv_utils.emulator_drivers.StopEmulation()
 
 
 def is_import(emu, va):
@@ -336,15 +110,13 @@ def emulate_function(emu, function_index, fva, return_address, max_instruction_c
     try:
         floss_logger.debug("Emulating function at 0x%08X", fva)
         driver = viv_utils.emulator_drivers.DebuggerEmulatorDriver(emu)
-        monitor = ApiMonitor(emu.vw, function_index)
+        monitor = api_hooks.ApiMonitor(emu.vw, function_index)
         driver.add_monitor(monitor)
         driver.add_hook(delta_collector)
-        driver.add_hook(GetProcessHeapHook())
-        driver.add_hook(RtlAllocateHeapHook())
-        driver.add_hook(AllocateHeap())
-        driver.add_hook(MallocHeap())
-        driver.add_hook(ExitProcessHook())
-        driver.runToVa(return_address, max_instruction_count)
+
+        with api_hooks.defaultHooks(driver):
+            driver.runToVa(return_address, max_instruction_count)
+
     except viv_utils.emulator_drivers.InstructionRangeExceededError:
         floss_logger.debug("Halting as emulation has escaped!")
     except envi.InvalidInstruction:

--- a/floss/function_argument_getter.py
+++ b/floss/function_argument_getter.py
@@ -3,6 +3,7 @@ from collections import namedtuple
 import viv_utils
 import viv_utils.emulator_drivers
 
+import api_hooks
 from utils import makeEmulator
 
 # TODO get return address from emu_snap
@@ -25,11 +26,10 @@ class CallMonitor(viv_utils.emulator_drivers.Monitor):
     def get_contexts(self):
         return self.function_contexts
 
-#    def prehook(self, emu, op, starteip):
-#        self.d("%s: %s", hex(starteip), op)
+    def prehook(self, emu, op, starteip):
+        self.d("%s: %s", hex(starteip), op)
 
 
-# TODO LoggingObject should have its own file or be in general utils...
 class FunctionArgumentGetter(viv_utils.LoggingObject):
     def __init__(self, vivisect_workspace):
         viv_utils.LoggingObject.__init__(self)
@@ -69,21 +69,28 @@ class FunctionArgumentGetter(viv_utils.LoggingObject):
         return caller_function_vas
 
     def get_contexts_via_monitor(self, fva, target_fva):
-        """ run the given function while collecting arguments to a target function """
-        monitor = self.setup_monitor(target_fva)
-        self.d("    emulating: %s, watching %s" % (hex(self.index[fva]), hex(target_fva)))
-        self.driver.runFunction(self.index[fva], maxhit=1, func_only=True)
-        contexts = monitor.get_contexts()
-        self.driver.remove_monitor(monitor)
+        """
+        run the given function while collecting arguments to a target function
+        """
+
+        try:
+            self.d("    emulating: %s, watching %s" % (hex(self.index[fva]), hex(target_fva)))
+            monitor = CallMonitor(self.vivisect_workspace, target_fva)
+            self.driver.add_monitor(monitor)
+
+            with api_hooks.defaultHooks(self.driver):
+                self.driver.runFunction(self.index[fva], maxhit=1, func_only=True)
+
+            contexts = monitor.get_contexts()
+
+        finally:
+            self.driver.remove_monitor(monitor)
+
         self.d("      results:")
         for c in contexts:
             self.d("        <context>")
-        return contexts
 
-    def setup_monitor(self, target_fva):
-        monitor = CallMonitor(self.vivisect_workspace, target_fva)
-        self.driver.add_monitor(monitor)
-        return monitor
+        return contexts
 
 
 def get_function_contexts(vw, fva):

--- a/tests/src/decode-from-heap/test.yml
+++ b/tests/src/decode-from-heap/test.yml
@@ -28,6 +28,3 @@ Build instructions (Cross compile for Windows on Linux): |
 
 Xfail:
     - Linux-32bit
-    - Windows-32bit
-    - Windows-64bit
-

--- a/tests/src/decode-string-with-header/test.yml
+++ b/tests/src/decode-string-with-header/test.yml
@@ -28,6 +28,3 @@ Build instructions (Cross compile for Windows on Linux): |
 
 Xfail:
     - Linux-32bit
-    - Windows-32bit
-    - Windows-64bit
-


### PR DESCRIPTION
Refactor hooks into their own file, so they can be used during brute force emulation and decoder routine emulation.

Add hook for `memcpy` and `calloc`.