### PR TITLE
test decode reencode: fix config

### DIFF
--- a/tests/src/decode-reencode-string/test.yml
+++ b/tests/src/decode-reencode-string/test.yml
@@ -5,7 +5,7 @@ Input buffer location: stack
 Output buffer location: stack
 
 Decoded strings:
-    - Hello world
+    - hello world
 
 Source files:
     - test-decode-reencode-string.c
@@ -31,6 +31,3 @@ Build instructions (Cross compile for Windows on Linux): |
 
 Xfail:
     - Linux-32bit
-    - Windows-32bit
-    - Windows-64bit
-


### PR DESCRIPTION
expected strings had incorrect captialization

closes #100, closes #101