### PR TITLE
better handle large files

### DIFF
--- a/floss/main.py
+++ b/floss/main.py
@@ -476,12 +476,11 @@ def main():
     if options.all_strings:
         floss_logger.info("Extracting static strings...")
         print_static_strings(sample_file_path, min_length=min_length, quiet=options.quiet)
-    elif magic not in SUPPORTED_FILE_MAGIC:
-        floss_logger.warning("Unsupported input file type, automatically extracting only static strings...")
-        print_static_strings(sample_file_path, min_length=min_length, quiet=options.quiet)
 
     if magic not in SUPPORTED_FILE_MAGIC:
         floss_logger.error("FLOSS currently supports the following formats: PE")
+        if not options.all_strings:
+            floss_logger.error("Recommend passing flag `-a` to extract static strings from any file type.")
         return
 
     floss_logger.info("Generating vivisect workspace")

--- a/floss/main.py
+++ b/floss/main.py
@@ -391,7 +391,7 @@ def create_script(sample_file_path, ida_python_file, decoded_strings):
     # TODO return, catch exception in main()
 
 
-def print_all_strings(path, min_length, quiet=False):
+def print_static_strings(path, min_length, quiet=False):
     """
     Print static ASCII and UTF-16 strings from provided file.
     :param path: input file
@@ -469,10 +469,11 @@ def main():
 
     if options.all_strings:
         floss_logger.info("Extracting static strings...")
-        print_all_strings(sample_file_path, min_length=min_length, quiet=options.quiet)
+        print_static_strings(sample_file_path, min_length=min_length, quiet=options.quiet)
 
     with open(sample_file_path, "rb") as f:
         magic = f.read(2)
+
     if magic != "MZ":
         floss_logger.error("FLOSS currently supports the following formats: PE")
         return

--- a/floss/main.py
+++ b/floss/main.py
@@ -451,6 +451,9 @@ def print_stack_strings(extracted_strings, min_length, quiet=False):
         print("")
 
 
+SUPPORTED_FILE_MAGIC = set(["MZ"])
+
+
 def main():
     # default to INFO, unless otherwise changed
     logging.basicConfig(level=logging.WARNING)
@@ -467,14 +470,17 @@ def main():
     sample_file_path = parse_sample_file_path(parser, args)
     min_length = parse_min_length_option(options.min_length)
 
-    if options.all_strings:
-        floss_logger.info("Extracting static strings...")
-        print_static_strings(sample_file_path, min_length=min_length, quiet=options.quiet)
-
     with open(sample_file_path, "rb") as f:
         magic = f.read(2)
 
-    if magic != "MZ":
+    if options.all_strings:
+        floss_logger.info("Extracting static strings...")
+        print_static_strings(sample_file_path, min_length=min_length, quiet=options.quiet)
+    elif magic not in SUPPORTED_FILE_MAGIC:
+        floss_logger.warning("Unsupported input file type, automatically extracting only static strings...")
+        print_static_strings(sample_file_path, min_length=min_length, quiet=options.quiet)
+
+    if magic not in SUPPORTED_FILE_MAGIC:
         floss_logger.error("FLOSS currently supports the following formats: PE")
         return
 

--- a/floss/main.py
+++ b/floss/main.py
@@ -514,6 +514,12 @@ def main():
             floss_logger.error("Recommend passing flag `-a` to extract static strings from any file type.")
         return
 
+    if os.path.getsize(sample_file_path) > MAX_FILE_SIZE:
+        floss_logger.error("FLOSS cannot emulate files larger than %d bytes" % (MAX_FILE_SIZE))
+        if not options.all_strings:
+            floss_logger.error("Recommend passing flag `-a` to extract static strings from any sized file.")
+        return
+
     floss_logger.info("Generating vivisect workspace")
     vw = viv_utils.getWorkspace(sample_file_path)
 

--- a/floss/main.py
+++ b/floss/main.py
@@ -29,7 +29,13 @@ from decoding_manager import LocationType
 floss_logger = logging.getLogger("floss")
 
 
-MIN_LENGTH_DEFAULT = 4
+KILOBYTE = 1024
+MEGABYTE = 1024 * KILOBYTE
+MAX_FILE_SIZE = 16 * MEGABYTE
+
+SUPPORTED_FILE_MAGIC = set(["MZ"])
+
+MIN_STRING_LENGTH_DEFAULT = 4
 
 
 def hex(i):
@@ -124,7 +130,7 @@ def make_parser():
     parser.add_option("-i", "--ida", dest="ida_python_file",
                         help="create an IDAPython script to annotate the decoded strings in an IDB file")
     parser.add_option("-n", "--minimum-length", dest="min_length",
-                        help="minimum string length (default is %d)" % MIN_LENGTH_DEFAULT)
+                      help="minimum string length (default is %d)" % MIN_STRING_LENGTH_DEFAULT)
     parser.add_option("-p", "--plugins", dest="plugins",
                         help="apply the specified identification plugins only (comma-separated)")
     parser.add_option("-l", "--list-plugins", dest="list_plugins",
@@ -253,7 +259,7 @@ def parse_min_length_option(min_length_option):
     """
     Return parsed -n command line option or default length.
     """
-    min_length = int(min_length_option or str(MIN_LENGTH_DEFAULT))
+    min_length = int(min_length_option or str(MIN_STRING_LENGTH_DEFAULT))
     return min_length
 
 
@@ -391,9 +397,6 @@ def create_script(sample_file_path, ida_python_file, decoded_strings):
             raise e
     # TODO return, catch exception in main()
 
-KILOBYTE = 1024
-MEGABYTE = 1024 * KILOBYTE
-MAX_FILE_SIZE = 16 * MEGABYTE
 
 def print_static_strings(path, min_length, quiet=False):
     """
@@ -485,9 +488,6 @@ def print_stack_strings(extracted_strings, min_length, quiet=False):
                 [(hex(s.fva), hex(s.frame_offset), s.s) for s in extracted_strings],
                 headers=["Function", "Frame Offset", "String"]))
         print("")
-
-
-SUPPORTED_FILE_MAGIC = set(["MZ"])
 
 
 def main():

--- a/floss/main.py
+++ b/floss/main.py
@@ -435,6 +435,11 @@ def print_static_strings(path, min_length, quiet=False):
             if not has_string:
                 print("none.")
             print("")
+
+            if os.path.getsize(path) > sys.maxint:
+                floss_logger.warning("File too large, strings listings may be trucated.")
+                floss_logger.warning("FLOSS cannot handle files larger than 4GB on 32bit systems.")
+
         else:
             # for reasonably sized files, we can read all the strings at once
             # and format them nicely in a table.


### PR DESCRIPTION
  - suggest providing flag -a for non-PE files
  - suggest providing flag -a for large files
  - extract static strings from large files
  - warn users of truncated static strings for 4GB files on 32bit systems