### PR TITLE
reformat code to adhere to pep8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ env:
 
 install:
     - pip install https://github.com/williballenthin/vivisect/zipball/master
-    - pip install pyinstaller
+    - pip install pyinstaller pep8
     - echo "__version__ = '$(git describe --tags)'" > floss/version.py
     - pip install -e .
     - sudo apt-get install -y git clang mingw-w64 gcc-mingw-w64 cmake make gcc-mingw-w64-x86-64 g++-mingw-w64-x86-64 binutils-mingw-w64-x86-64 mingw-w64-dev  binutils-mingw-w64-i686 gcc-mingw-w64-i686 g++-mingw-w64-i686
@@ -19,7 +19,9 @@ install:
     - pushd tests/src; make all; popd
     - pyinstaller floss.spec
 
-script: py.test tests/src/ -v
+script:
+    - find . -name \*.py -exec pep8 --ignore=E501 {} \;
+    - py.test tests/src/ -v
 
 addons:
     artifacts:

--- a/floss/api_hooks.py
+++ b/floss/api_hooks.py
@@ -8,6 +8,7 @@ class ApiMonitor(viv_utils.emulator_drivers.Monitor):
     '''
     The ApiMonitor observes emulation and cleans up API function returns.
     '''
+
     def __init__(self, vw, function_index):
         viv_utils.emulator_drivers.Monitor.__init__(self, vw)
         self.function_index = function_index
@@ -23,11 +24,12 @@ class ApiMonitor(viv_utils.emulator_drivers.Monitor):
         # to assist with debugging
         # add an address to this object, and you'll drop into an interactive shell
         bps = self.bps
-        #bps.add(0x401560)
+        # bps.add(0x401560)
         if startpc in bps:
             self.dumpState(emu)
             from hexdump import hexdump
-            from IPython import embed; embed()
+            from IPython import embed
+            embed()
 
         #self.d("%s: %s", hex(startpc), op)
 
@@ -147,6 +149,7 @@ class GetProcessHeapHook(viv_utils.emulator_drivers.Hook):
     '''
     Hook and handle calls to GetProcessHeap, returning 0.
     '''
+
     def hook(self, callname, emu, callconv, api, argv):
         if callname == "kernel32.GetProcessHeap":
             # nop
@@ -175,6 +178,7 @@ class RtlAllocateHeapHook(viv_utils.emulator_drivers.Hook):
     The base heap address is 0x69690000.
     The max allocation size is 10 MB.
     '''
+
     def __init__(self, *args, **kwargs):
         super(RtlAllocateHeapHook, self).__init__(*args, **kwargs)
         self._heap_addr = 0x69690000
@@ -207,6 +211,7 @@ class AllocateHeap(RtlAllocateHeapHook):
     '''
     Hook calls to AllocateHeap and handle them like calls to RtlAllocateHeapHook.
     '''
+
     def __init__(self, *args, **kwargs):
         super(AllocateHeap, self).__init__(*args, **kwargs)
 
@@ -226,6 +231,7 @@ class MallocHeap(RtlAllocateHeapHook):
     '''
     Hook calls to malloc and handle them like calls to RtlAllocateHeapHook.
     '''
+
     def __init__(self, *args, **kwargs):
         super(MallocHeap, self).__init__(*args, **kwargs)
 
@@ -244,6 +250,7 @@ class MemcpyHook(viv_utils.emulator_drivers.Hook):
     '''
     Hook and handle calls to memcpy.
     '''
+
     def __init__(self, *args, **kwargs):
         super(MemcpyHook, self).__init__(*args, **kwargs)
 
@@ -263,6 +270,7 @@ class ExitProcessHook(viv_utils.emulator_drivers.Hook):
     '''
     Hook calls to ExitProcess and stop emulation when these are hit.
     '''
+
     def __init__(self, *args, **kwargs):
         super(ExitProcessHook, self).__init__(*args, **kwargs)
 

--- a/floss/identification_manager.py
+++ b/floss/identification_manager.py
@@ -98,4 +98,3 @@ def identify_decoding_functions(vw, identification_plugins, functions):
     identification_manager.run_plugins(identification_plugins, functions)
     identification_manager.apply_plugin_weights()
     return identification_manager
-

--- a/floss/stackstrings.py
+++ b/floss/stackstrings.py
@@ -10,12 +10,12 @@ from utils import makeEmulator
 
 
 CallContext = namedtuple("CallContext",
-        [
-            "pc",  # the current program counter, type: int
-            "sp",  # the current stack counter, type: int
-            "init_sp",   # the initial stack counter at start of function, type: int
-            "stack_memory",  # the active stack frame contents, type: str
-        ])
+                         [
+                             "pc",  # the current program counter, type: int
+                             "sp",  # the current stack counter, type: int
+                             "init_sp",   # the initial stack counter at start of function, type: int
+                             "stack_memory",  # the active stack frame contents, type: str
+                         ])
 
 
 class CallContextMonitor(viv_utils.emulator_drivers.Monitor):
@@ -56,58 +56,58 @@ def extract_call_contexts(vw, fva):
 
 # StackString represents a stackstring extracted from a function.
 StackString = namedtuple("StackString",
-        [
-            # type: int
-            # the address from which the stackstring was extracted.
-            "fva",
+                         [
+                             # type: int
+                             # the address from which the stackstring was extracted.
+                             "fva",
 
-            # type: str
-            # the string contents.
-            "s",
+                             # type: str
+                             # the string contents.
+                             "s",
 
-            # type: int
-            # the program counter at which the stackstring existed.
-            "pc",
+                             # type: int
+                             # the program counter at which the stackstring existed.
+                             "pc",
 
-            # here's what the following members represent...
-            #
-            #
-            # [smaller addresses]
-            #
-            # +---------------+  <- sp (top of stack)
-            # |               | \
-            # +---------------+  | offset
-            # |               | /
-            # +---------------+
-            # | "abc"         | \
-            # +---------------+  |
-            # |               |  |
-            # +---------------+  | frame_offset
-            # |               |  |
-            # +---------------+  |
-            # |               | /
-            # +---------------+  <- init_sp (bottom of stack, probably bp)
-            #
-            # [bigger addresses]
+                             # here's what the following members represent...
+                             #
+                             #
+                             # [smaller addresses]
+                             #
+                             # +---------------+  <- sp (top of stack)
+                             # |               | \
+                             # +---------------+  | offset
+                             # |               | /
+                             # +---------------+
+                             # | "abc"         | \
+                             # +---------------+  |
+                             # |               |  |
+                             # +---------------+  | frame_offset
+                             # |               |  |
+                             # +---------------+  |
+                             # |               | /
+                             # +---------------+  <- init_sp (bottom of stack, probably bp)
+                             #
+                             # [bigger addresses]
 
-            # type: int
-            # the stack counter at which the stackstring existed.
-            # aka, the top of the stack frame
-            "sp",
+                             # type: int
+                             # the stack counter at which the stackstring existed.
+                             # aka, the top of the stack frame
+                             "sp",
 
-            # type: int
-            # the initial stack counter at the start of the function.
-            # aka, the bottom of the stack frame
-            "init_sp",
+                             # type: int
+                             # the initial stack counter at the start of the function.
+                             # aka, the bottom of the stack frame
+                             "init_sp",
 
-            # type: int
-            # the offset into the stack frame at which the stackstring existed.
-            "offset",
+                             # type: int
+                             # the offset into the stack frame at which the stackstring existed.
+                             "offset",
 
-            # type: int
-            # the offset from the function frame at which the stackstring existed.
-            "frame_offset",
-        ])
+                             # type: int
+                             # the offset from the function frame at which the stackstring existed.
+                             "frame_offset",
+                         ])
 
 
 def getPointerSize(vw):

--- a/floss/string_decoder.py
+++ b/floss/string_decoder.py
@@ -54,11 +54,11 @@ def emulate_decoding_routine(vw, function_index, function, context):
     floss_logger.debug("Emulating function at 0x%08X called at 0x%08X, return address: 0x%08X",
                        function, context.decoded_at_va, context.return_address)
     deltas = decoding_manager.emulate_function(
-                emu,
-                function_index,
-                function,
-                context.return_address,
-                20000)
+        emu,
+        function_index,
+        function,
+        context.return_address,
+        20000)
     return deltas
 
 

--- a/tests/append_test_data.py
+++ b/tests/append_test_data.py
@@ -41,7 +41,7 @@ def main():
         spec = yaml.safe_load(f)
 
     strings = spec["Decoded strings"]
-    test_dict = { "all": strings }
+    test_dict = {"all": strings}
     logging.info("created test dictionary from %s:\n  %s", spec_path, pformat(test_dict))
 
     for platform, archs in spec["Output Files"].items():

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -38,6 +38,7 @@ def pytest_collect_file(parent, path):
 
 
 class YamlFile(pytest.File):
+
     def collect(self):
         spec = yaml.safe_load(self.fspath.open())
         test_dir = os.path.dirname(str(self.fspath))
@@ -64,11 +65,12 @@ class FLOSSDecodingFunctionNotFound(Exception):
 
 
 class FLOSSTest(pytest.Item):
+
     def __init__(self, path, platform, arch, filename, spec):
         name = "{name:s}::{platform:s}::{arch:s}".format(
-                name=spec["Test Name"],
-                platform=platform,
-                arch=arch)
+            name=spec["Test Name"],
+            platform=platform,
+            arch=arch)
         super(FLOSSTest, self).__init__(name, path)
         self.spec = spec
         self.platform = platform
@@ -135,4 +137,3 @@ class FLOSSTest(pytest.Item):
                 "   expected: %s" % str(expected),
                 "   got: %s" % str(got),
             ])
-

--- a/tests/footer.py
+++ b/tests/footer.py
@@ -60,5 +60,3 @@ def write_footer(sample_path, test_dict):
     test_data = struct.pack("<II", file_size, data_len)
     with open(sample_path, "ab") as f:
         f.write(json_data + test_data + MAGIC)
-
-


### PR DESCRIPTION
pep8 

excludes E501 (line width limited to 80 characters), since this blindly adds a bunch of line breaks that increases indentation and weird structure. some lines could be shorter, but i dont think we should require exactly 80 chars or less.