### PR TITLE
build nightly OSX binaries on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,7 @@
+os:
+  - linux
+  - osx
+
 language: python
 python:
   - "2.7"
@@ -13,19 +17,19 @@ install:
     - pip install pyinstaller pep8
     - echo "__version__ = '$(git describe --tags)'" > floss/version.py
     - pip install -e .
-    - sudo apt-get install -y git clang mingw-w64 gcc-mingw-w64 cmake make gcc-mingw-w64-x86-64 g++-mingw-w64-x86-64 binutils-mingw-w64-x86-64 mingw-w64-dev  binutils-mingw-w64-i686 gcc-mingw-w64-i686 g++-mingw-w64-i686
-    - git clone https://github.com/tpoechtrager/wclang.git ../wclang
-    - pushd ../wclang; cmake -DCMAKE_INSTALL_PREFIX=/usr/local && make && sudo make install; popd
-    - pushd tests/src; make all; popd
+    - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo apt-get install -y git clang mingw-w64 gcc-mingw-w64 cmake make gcc-mingw-w64-x86-64 g++-mingw-w64-x86-64 binutils-mingw-w64-x86-64 mingw-w64-dev  binutils-mingw-w64-i686 gcc-mingw-w64-i686 g++-mingw-w64-i686; fi
+    - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then git clone https://github.com/tpoechtrager/wclang.git ../wclang; fi
+    - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then pushd ../wclang; cmake -DCMAKE_INSTALL_PREFIX=/usr/local && make && sudo make install; popd; fi
+    - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then pushd tests/src; make all; popd; fi
     - pyinstaller floss.spec
 
 script:
     - find . -name \*.py -exec pep8 --ignore=E501 {} \;
-    - py.test tests/src/ -v
+    - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then py.test tests/src/ -v; fi
 
 addons:
     artifacts:
         debug: true
         paths:
             - $(find . -type f | grep -e '/bin/' -e 'dist/floss$' | awk 1 ORS=':')
-        target_paths: travis/
+        target_paths: travis/$TRAVIS_OS_NAME/

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,10 +12,14 @@ matrix:
           sudo: required
           python: 2.7
 
+        # travis doesn't have py2.7 available, so we have to do it ourselves
+        # ref: https://github.com/travis-ci/travis-ci/issues/2312
         - os: osx
           language: generic
 
 before_install:
+    # travis doesn't have py2.7 available, so we have to do it ourselves
+    # ref: https://github.com/travis-ci/travis-ci/issues/2312
     - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
         git clone https://github.com/MacPython/terryfy ../terryfy;
         source ../terryfy/travis_tools.sh;
@@ -28,6 +32,7 @@ install:
     - echo "__version__ = '$(git describe --tags)'" > floss/version.py
     - pip install -e .
     - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
+        # haven't figured how to build wclang on osx yet, so don't build tests
         sudo apt-get install -y git clang mingw-w64 gcc-mingw-w64 cmake make gcc-mingw-w64-x86-64 g++-mingw-w64-x86-64 binutils-mingw-w64-x86-64 mingw-w64-dev  binutils-mingw-w64-i686 gcc-mingw-w64-i686 g++-mingw-w64-i686;
         git clone https://github.com/tpoechtrager/wclang.git ../wclang;
         pushd ../wclang; cmake -DCMAKE_INSTALL_PREFIX=/usr/local && make && sudo make install; popd;
@@ -38,6 +43,7 @@ install:
 script:
     - find . -name \*.py -exec pep8 --ignore=E501 {} \;
     - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
+        # haven't figured how to build wclang on osx yet, so no tests
         py.test tests/src/ -v;
       fi
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,31 +1,45 @@
-os:
-  - linux
-  - osx
-
-language: python
-python:
-  - "2.7"
-
 env:
     global:
         - secure: "IsTn+3KFldcyDwp6p48ovav0whLDYa8fQuQW0ygwp2FDMO0ni9c/UqybqGsd9+2MNXanravCCjuNA4yLCntoQcLWttQLEqVUnrDqwhrH/PJYWiTLKeQUKVCXywc+jpJifDJCXA7XFMX2fKAvoSSpcu8FSb0J2guGHMoWphQgRdbXPzy01GdApq3fXhchk5IG6FDTVXkBvijj2FseIhanT89AMWoD+xsOfO+EVICS6zYPv6TCVeNvhjAeXA2EjSTNYgA/P8W46hcOmvt4D2pg6xQ2D9OLi9D6OZClJMOnt5yOdalPHjFs51DyzuZ2aQ7rgr5MOiNVbLT1AFX0PSa8DvXgMwx4BHfEjbs5HNICUDXkYGRMvcnkpU9rz2/HdmT9h9J2nKmIERvtjviITkRthmzR7oU/ejuL/stT+Y7cosnlqb43nCsQ/SnVkcYjPsK/v5y/Q45uXhMbwqRqg0E/ffr+5nqM0WDDOKsdcrihhURtBcqBSyVrXcSuX3wTGcA/WCmwa/vzWwp/rIF7g+TVb/eRx6Pk8KDS5rx5kwSC7+ZKfYFxW0++S7CMWWIoKSItF6oR2jXmJQGxdjMkVhYwOTLTGpgEhK4U1uEjKIzxPnn5wQ9nX8iN1/2x3Ph4sQF3iUrGGFRAj6+Ys1yMfFxZcJxVDop8LhUqsmXzXXkmx+w="
         - secure: "Cv1Go29ovzdhLqtI+bzYltUy6WrdYIaRqfqK97kzddMSmjrFkednOOXhnyIWyGggqlX10tsaX7B4Rrf6QosCpao1tcMlShQJv0+uWDm//E3zOybWaUbSD+TZDZoHXKGX/d2/3y6fQIKW9pA7hQt1B3zrJyRnB08Pn1nrVBzKtvFfgrXCxeEveHTqcnaUF5hMc6/2vECCTS9nxp8b7rt2Ow4ew5XRsm9oR3WIzFdatDtKz1L7ot9W2Q8odBVYn7siaWLe/9xoF5qguv6Qk+FJRI4DztL/HAtQBz0xVqaf8Xgx4cMb9rqmt8ZZPkZELK7Wk1txlcimCNXncY+aU2eiA2eWpAvR42IqxxLkGpSzv+4Eh29/f5qpdiFXWpbKudRida/Ow925CFzXk0XWYhytNLrqwAVlUn2taKUsKVsW6t2SrMYrEkMarmlJGkq514LZfTeWmqLyyVImbyarsVQoZ+GcAdvPex4nGFFdO53GggptctQH4NCncT3FpEqMgxXKJ179h2tdG85nqgk2Yd38BXkMzjeXocMByi3Ax+2BmbBIRaIYcZAuIFmN371FWjF8EMtIQgUY4EgIlpykjYQ2BhphJMY7lkjN5Q8eTt7X6rO7EQOmqKtNpW5wcVbwpmrfSbQcYHFTB6Om1DIYVtEILu4NHOJZJ4qTT6UghL3/2jQ="
         - ARTIFACTS_BUCKET=build-artifacts.floss.flare.fireeye.com
 
+language: python
+
+matrix:
+    include:
+        - os: linux
+          sudo: required
+          python: 2.7
+
+        - os: osx
+          language: generic
+
+before_install:
+    - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
+        git clone https://github.com/MacPython/terryfy ../terryfy;
+        source ../terryfy/travis_tools.sh;
+        get_python_environment macpython 2.7.10;
+      fi
+
 install:
     - pip install https://github.com/williballenthin/vivisect/zipball/master
     - pip install pyinstaller pep8
     - echo "__version__ = '$(git describe --tags)'" > floss/version.py
     - pip install -e .
-    - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo apt-get install -y git clang mingw-w64 gcc-mingw-w64 cmake make gcc-mingw-w64-x86-64 g++-mingw-w64-x86-64 binutils-mingw-w64-x86-64 mingw-w64-dev  binutils-mingw-w64-i686 gcc-mingw-w64-i686 g++-mingw-w64-i686; fi
-    - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then git clone https://github.com/tpoechtrager/wclang.git ../wclang; fi
-    - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then pushd ../wclang; cmake -DCMAKE_INSTALL_PREFIX=/usr/local && make && sudo make install; popd; fi
-    - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then pushd tests/src; make all; popd; fi
+    - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
+        sudo apt-get install -y git clang mingw-w64 gcc-mingw-w64 cmake make gcc-mingw-w64-x86-64 g++-mingw-w64-x86-64 binutils-mingw-w64-x86-64 mingw-w64-dev  binutils-mingw-w64-i686 gcc-mingw-w64-i686 g++-mingw-w64-i686;
+        git clone https://github.com/tpoechtrager/wclang.git ../wclang;
+        pushd ../wclang; cmake -DCMAKE_INSTALL_PREFIX=/usr/local && make && sudo make install; popd;
+        pushd tests/src; make all; popd;
+      fi
     - pyinstaller floss.spec
 
 script:
     - find . -name \*.py -exec pep8 --ignore=E501 {} \;
-    - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then py.test tests/src/ -v; fi
+    - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
+        py.test tests/src/ -v;
+      fi
 
 addons:
     artifacts:

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ For a detailed description of *installing* FLOSS, review the documention
 Standalone nightly builds:
   - Windows: [here](http://s3.amazonaws.com/build-artifacts.floss.flare.fireeye.com/appveyor/dist/floss.exe)
   - Linux: [here](https://s3.amazonaws.com/build-artifacts.floss.flare.fireeye.com/travis/dist/linux/floss)
+  - OSX: [here](https://s3.amazonaws.com/build-artifacts.floss.flare.fireeye.com/travis/dist/osx/floss)
 
 
 ## Usage

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ For a detailed description of *installing* FLOSS, review the documention
 
 Standalone nightly builds:
   - Windows: [here](http://s3.amazonaws.com/build-artifacts.floss.flare.fireeye.com/appveyor/dist/floss.exe)
-  - Linux: [here](https://s3.amazonaws.com/build-artifacts.floss.flare.fireeye.com/travis/dist/floss)
+  - Linux: [here](https://s3.amazonaws.com/build-artifacts.floss.flare.fireeye.com/travis/dist/linux/floss)
 
 
 ## Usage

--- a/floss/api_hooks.py
+++ b/floss/api_hooks.py
@@ -31,7 +31,7 @@ class ApiMonitor(viv_utils.emulator_drivers.Monitor):
             from IPython import embed
             embed()
 
-        #self.d("%s: %s", hex(startpc), op)
+        # self.d("%s: %s", hex(startpc), op)
 
     def posthook(self, emu, op, endpc):
         # overridden from Monitor


### PR DESCRIPTION
travis doesn't have a python2.7 environment available, so we have to do some manual setup. pyinstaller runs just fine. haven't attempted to execute the exe since i dont have an osx system.

haven't enabled running the tests cause i have no idea how to get clang cross compiling working on osx, and don't have an osx system handy. we'll defer to the linux travis config for regression testing.

closes #154