### PR TITLE
Memdiff rewrite

### DIFF
--- a/floss/string_decoder.py
+++ b/floss/string_decoder.py
@@ -17,10 +17,8 @@ def memdiff_search(a, b):
 
     :param a: The original sequence of bytes
     :param b: The sequence of bytes to compare with
-    :param offset: Offset to be added to the return value
     :type a: str
     :type b: str
-    :type offset: int
     :rtype: int offset of the first location a and b differ, None if strings match
     '''
 

--- a/floss/string_decoder.py
+++ b/floss/string_decoder.py
@@ -48,7 +48,7 @@ def memdiff(bytes1, bytes2):
     :type bytes1: str
     :type bytes2: str
     :rtype: list of (offset, length) tuples indicating locations bytes1 and
-      bytes 2 differ
+      bytes2 differ
     '''
     # Shortcut matching inputs
     if bytes1 == bytes2:

--- a/floss/string_decoder.py
+++ b/floss/string_decoder.py
@@ -10,33 +10,33 @@ from decoding_manager import DecodedString, LocationType
 floss_logger = logging.getLogger("floss")
 
 
-def memdiff_search(a, b):
+def memdiff_search(bytes1, bytes2):
     '''
     Use binary searching to find the offset of the first difference
      between two strings.
 
-    :param a: The original sequence of bytes
-    :param b: The sequence of bytes to compare with
-    :type a: str
-    :type b: str
+    :param bytes1: The original sequence of bytes
+    :param bytes2: A sequence of bytes to compare with bytes1
+    :type bytes1: str
+    :type bytes2: str
     :rtype: int offset of the first location a and b differ, None if strings match
     '''
 
     # Prevent infinite recursion on inputs with length of one
-    half = (len(a) / 2) or 1
+    half = (len(bytes1) / 2) or 1
 
     # Compare first half of the string
-    if a[:half] != b[:half]:
+    if bytes1[:half] != bytes2[:half]:
 
         # Have we found the first diff?
-        if a[0] != b[0]:
+        if bytes1[0] != bytes2[0]:
             return 0
 
-        return memdiff_search(a[:half], b[:half])
+        return memdiff_search(bytes1[:half], bytes2[:half])
 
     # Compare second half of the string
-    if a[half:] != b[half:]:
-        return memdiff_search(a[half:], b[half:]) + half
+    if bytes1[half:] != bytes2[half:]:
+        return memdiff_search(bytes1[half:], bytes2[half:]) + half
 
 
 def memdiff(bytes1, bytes2):

--- a/floss/string_decoder.py
+++ b/floss/string_decoder.py
@@ -46,7 +46,7 @@ def memdiff(bytes1, bytes2):
     Find all differences between two input strings.
 
     :param bytes1: The original sequence of bytes
-    :param bytes2: A different sequence of bytes to compare to
+    :param bytes2: The sequence of bytes to compare to
     :type bytes1: str
     :type bytes2: str
     :rtype: list of (offset, length) tuples indicating locations bytes1 and

--- a/floss/string_decoder.py
+++ b/floss/string_decoder.py
@@ -10,7 +10,7 @@ from decoding_manager import DecodedString, LocationType
 floss_logger = logging.getLogger("floss")
 
 
-def memdiff_search(a, b, offset=0):
+def memdiff_search(a, b):
     '''
     Use binary searching to find the offset of the first difference
      between two strings.
@@ -32,13 +32,13 @@ def memdiff_search(a, b, offset=0):
 
         # Have we found the first diff?
         if a[0] != b[0]:
-            return offset
+            return 0
 
-        return memdiff_search(a[:half], b[:half]) + offset
+        return memdiff_search(a[:half], b[:half])
 
     # Compare second half of the string
     if a[half:] != b[half:]:
-        return memdiff_search(a[half:], b[half:], offset=half) + offset
+        return memdiff_search(a[half:], b[half:]) + half
 
 
 def memdiff(bytes1, bytes2):

--- a/floss/string_decoder.py
+++ b/floss/string_decoder.py
@@ -1,7 +1,5 @@
 import logging
 
-import envi.memory
-
 import strings
 import decoding_manager
 from utils import makeEmulator
@@ -162,7 +160,7 @@ def extract_delta_bytes(delta, decoded_at_va, source_fva=0x0):
         section_before = mem_before[section_after_start]
         (_, _, _, bytes_before) = section_before
 
-        memory_diff = envi.memory.memdiff(bytes_before, bytes_after)
+        memory_diff = memdiff(bytes_before, bytes_after)
         for offset, length in memory_diff:
             address = section_after_start + offset
 

--- a/floss/string_decoder.py
+++ b/floss/string_decoder.py
@@ -42,7 +42,7 @@ def memdiff(bytes1, bytes2):
 
     diffs = []
 
-    # Get offset of first diff
+    # Get position of first diff
     diff_start = memdiff_search(bytes1, bytes2)
     diff_offset = None
     for offset, byte in enumerate(bytes1[diff_start:]):
@@ -65,6 +65,7 @@ def memdiff(bytes1, bytes2):
     # Bytes are different until the end of input, handle leftovers
     if diff_offset is not None:
         diffs.append((diff_offset + diff_start, offset + 1 - diff_offset))
+
     return diffs
 
 

--- a/floss/string_decoder.py
+++ b/floss/string_decoder.py
@@ -11,6 +11,19 @@ floss_logger = logging.getLogger("floss")
 
 
 def memdiff_search(a, b, offset=0):
+    '''
+    Use binary searching to find the offset of the first difference
+     between two strings.
+
+    :param a: The original sequence of bytes
+    :param b: The sequence of bytes to compare with
+    :param offset: Offset to be added to the return value
+    :type a: str
+    :type b: str
+    :type offset: int
+    :rtype: int offset of the first location a and b differ, None if strings match
+    '''
+
     # Prevent infinite recursion on inputs with length of one
     half = (len(a) / 2) or 1
 
@@ -29,6 +42,16 @@ def memdiff_search(a, b, offset=0):
 
 
 def memdiff(bytes1, bytes2):
+    '''
+    Find all differences between two input strings.
+
+    :param bytes1: The original sequence of bytes
+    :param bytes2: A different sequence of bytes to compare to
+    :type bytes1: str
+    :type bytes2: str
+    :rtype: list of (offset, length) tuples indicating locations bytes1 and
+      bytes 2 differ
+    '''
     # Shortcut matching inputs
     if bytes1 == bytes2:
         return []

--- a/tests/test_memdiff.py
+++ b/tests/test_memdiff.py
@@ -5,7 +5,6 @@ import envi.memory
 from floss.string_decoder import memdiff
 
 
-
 basic_tests = [
     # Empty strings
     ("", ""),
@@ -51,7 +50,7 @@ complex_tests = [
     # Midpoint diff
     ("A" * 800, ("A" * 399) + "BB" + ("A" * 399)),
     # 7 diffs, each 100 characters apart
-    ("A" * 800, ("A" * 100) + "B" + ("A" * 100) + "B" + ("A" * 100) + "B" + ("A" * 100) + "B" + ("A" * 100) + "B" + ("A" * 100) + "B" + ("A" * 100) + "B" + ("A" * 93)),
+    ("A" * 800, ((("A" * 100) + "B") * 7) + ("A" * 93)),
 ]
 
 

--- a/tests/test_memdiff.py
+++ b/tests/test_memdiff.py
@@ -1,0 +1,60 @@
+import pytest
+
+import envi.memory
+
+from floss.string_decoder import memdiff
+from floss.string_decoder import memdiff_search
+
+
+
+basic_tests = [
+    # Empty strings
+    ("", ""),
+    # Single byte matching
+    ("a", "a"),
+    # Single byte diffing
+    ("a", "b"),
+    # Multi-byte first character diff
+    ("aaa", "baa"),
+    # Multi-byte mid character diff
+    ("aaa", "aba"),
+    # multi-byte last character diff
+    ("aaa", "aab"),
+    # Multi-byte multi-diff
+    ("aaaa", "abab"),
+]
+
+def test_basics():
+    for a, b in basic_tests:
+        assert envi.memory.memdiff(a, b) == memdiff(a, b)
+
+    # Make sure we're throwing an exception on different length strings
+    with pytest.raises(Exception):
+        memdiff("a", "aa")
+
+
+complex_tests = [
+    # 32 byte diff in the second half of the input string
+    ("A" * 800, ("A" * 512) + ("B" * 32) + ("A" * 256)),
+    # 32 byte diff in the first half of the input string
+    ("A" * 800, ("A" * 256) + ("B" * 32) + ("A" * 512)),
+    # early 512 byte  diff
+    ("A" * 800, ("A" * 32) + ("B" * 512) + ("A" * 256)),
+    # End of line diff
+    ("A" * 800, ("A" * 799) + "B"),
+    # Beginning of line diff
+    ("A" * 800, "B" + ("A" * 799)),
+    # Midpoint diff
+    ("A" * 800, ("A" * 400) + "B" + ("A" * 399)),
+    # Midpoint diff
+    ("A" * 800, ("A" * 399) + "B" + ("A" * 400)),
+    # Midpoint diff
+    ("A" * 800, ("A" * 399) + "BB" + ("A" * 399)),
+    # 7 diffs, each 100 characters apart
+    ("A" * 800, ("A" * 100) + "B" + ("A" * 100) + "B" + ("A" * 100) + "B" + ("A" * 100) + "B" + ("A" * 100) + "B" + ("A" * 100) + "B" + ("A" * 100) + "B" + ("A" * 93)),
+]
+
+
+def test_complex():
+    for a, b in complex_tests:
+        assert envi.memory.memdiff(a, b) == memdiff(a, b)

--- a/tests/test_memdiff.py
+++ b/tests/test_memdiff.py
@@ -3,7 +3,6 @@ import pytest
 import envi.memory
 
 from floss.string_decoder import memdiff
-from floss.string_decoder import memdiff_search
 
 
 

--- a/tests/test_memdiff.py
+++ b/tests/test_memdiff.py
@@ -23,6 +23,7 @@ basic_tests = [
     ("aaaa", "abab"),
 ]
 
+
 def test_basics():
     for a, b in basic_tests:
         assert envi.memory.memdiff(a, b) == memdiff(a, b)


### PR DESCRIPTION
Currently, ~25% of FLOSS processing time is spent in envi.memory.memdiff.

Doing a little research into the arguments/output, I noticed a few patterns:

- The average input size is ~150kb
- The average amount of diffs per call is ~1
- The average diff starts ~50% of the way through the input
- The average diff is ~10 bytes long

This made a few optimizations pretty obvious, which are implemented with a new memdiff function:

- Try to locate the first diff without manually comparing each individual byte (binary search)
- After each diff, check if the remaining bytes are equivalent 

I'm running some tests to verify no regression in functionality, but so far everything looks good. 

The only concern I have with this implementation is that memdiff_search **may** hit the recursion limit on extremely long inputs with a diff located in specific locations. However, after a few hundred runs on random samples, I haven't seen it come anywhere close to that.

cProfile comparison of before/after runs show an almost 25% improvement in run time: https://gist.github.com/pilate/b825f84b0494afce0f134a909bfbabd2
