### PR TITLE
skip extraction on bufs of one repeated character

### DIFF
--- a/floss/strings.py
+++ b/floss/strings.py
@@ -5,6 +5,7 @@ from collections import namedtuple
 ASCII_BYTE = " !\"#\$%&\'\(\)\*\+,-\./0123456789:;<=>\?@ABCDEFGHIJKLMNOPQRSTUVWXYZ\[\]\^_`abcdefghijklmnopqrstuvwxyz\{\|\}\\\~\t"
 ASCII_RE_4 = re.compile("([%s]{%d,})" % (ASCII_BYTE, 4))
 UNICODE_RE_4 = re.compile(b"((?:[%s]\x00){%d,})" % (ASCII_BYTE, 4))
+REPEATS = ["A", "\x00", "\xfe", "\xff"]
 
 
 String = namedtuple("String", ["s", "offset"])
@@ -20,6 +21,9 @@ def extract_ascii_strings(buf, n=4):
     :type n: int
     :rtype: Sequence[String]
     '''
+    if (buf[0] in REPEATS) and (buf.count(buf[0]) == len(buf)):
+        return
+
     r = None
     if n == 4:
         r = ASCII_RE_4
@@ -40,6 +44,9 @@ def extract_unicode_strings(buf, n=4):
     :type n: int
     :rtype: Sequence[String]
     '''
+    if (buf[0] in REPEATS) and (buf.count(buf[0]) == len(buf)):
+        return
+
     if n == 4:
         r = UNICODE_RE_4
     else:

--- a/floss/strings.py
+++ b/floss/strings.py
@@ -21,6 +21,10 @@ def extract_ascii_strings(buf, n=4):
     :type n: int
     :rtype: Sequence[String]
     '''
+
+    if not buf:
+        return
+
     if (buf[0] in REPEATS) and (buf.count(buf[0]) == len(buf)):
         return
 
@@ -44,6 +48,10 @@ def extract_unicode_strings(buf, n=4):
     :type n: int
     :rtype: Sequence[String]
     '''
+
+    if not buf:
+        return
+
     if (buf[0] in REPEATS) and (buf.count(buf[0]) == len(buf)):
         return
 


### PR DESCRIPTION
I was running into some samples* that were spending over 10 minutes in extract_unicode_strings. Debugging the calls, there were thousands of occurrences of inputs consisting of all "A" and NULL characters, occasionally over 2gb in size.

This patch shortcuts the extract functions if a buf consists of nothing but a single repeated 'banned' character.

I went with .count instead of multiplication because of the sizes of some inputs.

Before/after profile: https://gist.github.com/pilate/45907ae43a85292fcd7393aed2c25d2e

* aa8a1c3afdf1d9b16fae80e6444d5889