### PR TITLE
show cleaner error message on getWorkspace failure

### DIFF
--- a/floss/main.py
+++ b/floss/main.py
@@ -563,7 +563,11 @@ def main(argv=None):
     if options.expert:
         options.save_workspace = True
 
-    vw = viv_utils.getWorkspace(sample_file_path, should_save=options.save_workspace)
+    try:
+        vw = viv_utils.getWorkspace(sample_file_path, should_save=options.save_workspace)
+    except Exception, e:
+        print("Vivisect failed to load the input file: {0}".format(e.message))
+        sys.exit(1)
 
     selected_functions = select_functions(vw, options.functions)
     floss_logger.debug("Selected the following functions: %s", ", ".join(map(hex, selected_functions)))


### PR DESCRIPTION
Basic handling of getWorkspace errors. Using this locally for cleaner output, not sure if you guys want it in or not.

Patched outputs:

$ python floss/main.py f12e2a67-20b4-5469-ac65-379b89196b3a
Vivisect failed to load the input file: bad char in struct format

$ python floss/main.py 82afe1bd-878e-5b27-b4f9-636393a3fbcb
Vivisect failed to load the input file: Machine 0401 is not supported for PE!
