### PR TITLE
Improvements to IDA script output, escaping

### DIFF
--- a/floss/main.py
+++ b/floss/main.py
@@ -66,9 +66,7 @@ def sanitize_string_for_printing(s):
     :param s: input string
     :return: sanitized string
     """
-    sanitized_string = s.replace('\n', '\\n')
-    sanitized_string = sanitized_string.replace('\r', '\\r')
-    sanitized_string = sanitized_string.replace('\t', '\\t')
+    sanitized_string = s.encode('unicode_escape')
     sanitized_string = "".join(c for c in sanitized_string if c in string.printable)
     return sanitized_string
 

--- a/floss/stackstrings.py
+++ b/floss/stackstrings.py
@@ -1,3 +1,5 @@
+import re
+
 from collections import namedtuple
 
 import viv_utils
@@ -128,10 +130,12 @@ def extract_stackstrings(vw, selected_functions):
     '''
     for fva in selected_functions:
         seen = set([])
+        filter = re.compile("^p?V?A+$")
         for ctx in extract_call_contexts(vw, fva):
             for s in strings.extract_ascii_strings(ctx.stack_memory):
-                if s.s == "A" * len(s.s):
-                    # ignore vivisect taint strings
+                if filter.match(s.s):
+                    # ignore strings like: pVA, pVAAA, AAAA
+                    # which come from vivisect uninitialized taint tracking
                     continue
                 if s.s not in seen:
                     frame_offset = (ctx.init_sp - ctx.sp) - s.offset - getPointerSize(vw)


### PR DESCRIPTION
- Includes stackstrings: adds repeatable comment to stack offset, if it can be located
- Improved character escaping for immediate and script output
- General improvements to script output

Unrelated:
- Apply filter regex to stackstrings