### PR TITLE
use logging for vivisect failures

### DIFF
--- a/floss/main.py
+++ b/floss/main.py
@@ -566,7 +566,7 @@ def main(argv=None):
     try:
         vw = viv_utils.getWorkspace(sample_file_path, should_save=options.save_workspace)
     except Exception, e:
-        print("Vivisect failed to load the input file: {0}".format(e.message))
+        floss_logger.error("Vivisect failed to load the input file: {0}".format(e.message), exc_info=options.verbose)
         sys.exit(1)
 
     selected_functions = select_functions(vw, options.functions)


### PR DESCRIPTION
re #183 #184 
```
$ python floss/main.py -v dbfed143-a35f-547f-ac68-9d70efc6c92c
INFO:floss:Generating vivisect workspace
ERROR:floss:Vivisect failed to load the input file: Machine 0301 is not supported for PE!
Traceback (most recent call last):
  File "floss/main.py", line 567, in main
    vw = viv_utils.getWorkspace(sample_file_path, should_save=options.save_workspace)
  File "/usr/local/lib/python2.7/dist-packages/viv_utils-0.3.3-py2.7.egg/viv_utils/__init__.py", line 32, in getWorkspace
    vw.loadFromFile(fp)
  File "/usr/local/lib/python2.7/dist-packages/vivisect-0.0.0-py2.7.egg/vivisect/__init__.py", line 2134, in loadFromFile
    fname = mod.parseFile(self, filename)
  File "/usr/local/lib/python2.7/dist-packages/vivisect-0.0.0-py2.7.egg/vivisect/parsers/pe.py", line 30, in parseFile
    return loadPeIntoWorkspace(vw, pe, filename)
  File "/usr/local/lib/python2.7/dist-packages/vivisect-0.0.0-py2.7.egg/vivisect/parsers/pe.py", line 65, in loadPeIntoWorkspace
    raise Exception("Machine %.4x is not supported for PE!" % mach )
Exception: Machine 0301 is not supported for PE!
```
```
$ python floss/main.py  dbfed143-a35f-547f-ac68-9d70efc6c92c
ERROR:floss:Vivisect failed to load the input file: Machine 0301 is not supported for PE!
```