### PR TITLE
Resized memory

### DIFF
--- a/floss/string_decoder.py
+++ b/floss/string_decoder.py
@@ -172,15 +172,20 @@ def extract_delta_bytes(delta, decoded_at_va, source_fva=0x0):
     # iterate memory from after the decoding, since if somethings been allocated,
     # we want to know. don't care if things have been deallocated.
     for section_after_start, section_after in mem_after.items():
-        (_, _, _, bytes_after) = section_after
+        (_, _, (_, after_len, _, _), bytes_after) = section_after
         if section_after_start not in mem_before:
             characteristics = {"location_type": LocationType.HEAP}
             delta_bytes.append(DecodedString(section_after_start, bytes_after,
                                              decoded_at_va, source_fva, characteristics))
             continue
-
         section_before = mem_before[section_after_start]
-        (_, _, _, bytes_before) = section_before
+        (_, _, (_, before_len, _, _), bytes_before) = section_before
+
+        if after_len < before_len:
+            bytes_before = bytes_before[:after_len]
+
+        elif after_len > before_len:
+            bytes_before += "\x00" * (after_len - before_len)
 
         memory_diff = memdiff(bytes_before, bytes_after)
         for offset, length in memory_diff:

--- a/floss/string_decoder.py
+++ b/floss/string_decoder.py
@@ -178,6 +178,7 @@ def extract_delta_bytes(delta, decoded_at_va, source_fva=0x0):
             delta_bytes.append(DecodedString(section_after_start, bytes_after,
                                              decoded_at_va, source_fva, characteristics))
             continue
+
         section_before = mem_before[section_after_start]
         (_, _, (_, before_len, _, _), bytes_before) = section_before
 

--- a/floss/string_decoder.py
+++ b/floss/string_decoder.py
@@ -186,11 +186,6 @@ def extract_delta_bytes(delta, decoded_at_va, source_fva=0x0):
         for offset, length in memory_diff:
             address = section_after_start + offset
 
-            if stack_start <= address <= sp:
-                # every stack address that exceeds the stack pointer can be
-                # ignored because it is local to child stack frame
-                continue
-
             diff_bytes = bytes_after[offset:offset + length]
             if not (stack_start <= address < stack_end):
                 # address is in global memory


### PR DESCRIPTION
Should close #214 

If 'before' memory is larger than 'after' memory, truncate to same length.

If 'before' memory is smaller than 'after' memory, pad it with null characters to the same length
