### PR TITLE
Fix performance regression of buf_filled_with function

### DIFF
--- a/floss/strings.py
+++ b/floss/strings.py
@@ -7,15 +7,28 @@ ASCII_RE_4 = re.compile("([%s]{%d,})" % (ASCII_BYTE, 4))
 UNICODE_RE_4 = re.compile(b"((?:[%s]\x00){%d,})" % (ASCII_BYTE, 4))
 REPEATS = ["A", "\x00", "\xfe", "\xff"]
 
+SLICE_SIZE = 4096
 
 String = namedtuple("String", ["s", "offset"])
 
 def buf_filled_with(buf, c):
-    for i in range(len(buf)):
-        if buf[i] != c:
+    if hasattr(buf, 'count'):
+        return buf.count(c) == len(buf)
+
+    begin = 0
+    end = 0
+    while begin < len(buf):
+        end = begin + SLICE_SIZE
+        if end > len(buf):
+            end = len(buf)
+
+        if not buf[begin:end].count(c) == (end - begin):
             return False
 
+        begin = end
+
     return True
+
 
 def extract_ascii_strings(buf, n=4):
     '''


### PR DESCRIPTION
because of previous modification #204  of `strings.py`, performance of `buf_filled_with` is bad.
but anyway, `mmap object` has no `count` method, I have to implement it with pure python.
now, `mmap object` + `buf_filled_with` is even **faster** than `read` + `count`.

here is test script and full performance testing report: https://github.com/shizhx/others/tree/master/flare-floss_test

part of performance testing report:
use `read` with `count`
-------------------------------
```
2048MB sample:
         1918 function calls (1898 primitive calls) in 11.757 seconds

   Ordered by: cumulative time

   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
        1    0.051    0.051   11.757   11.757 strings_count.py:1(<module>)
        1    0.000    0.000   11.702   11.702 strings_count.py:89(main)
        1    7.188    7.188    7.188    7.188 {method 'read' of 'file' objects}
        2    4.514    2.257    4.514    2.257 {method 'count' of 'str' objects}
        1    0.000    0.000    2.297    2.297 strings_count.py:33(extract_ascii_strings)
        1    0.000    0.000    2.217    2.217 strings_count.py:60(extract_unicode_strings)
```

use `mmap` with `buf_filled_with`
---------------------------------------------
```
2048MB sample:
         3147648 function calls (3147628 primitive calls) in 8.093 seconds

   Ordered by: cumulative time

   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
        1    0.043    0.043    8.093    8.093 strings_buf_filled_with.py:1(<module>)
        1    0.000    0.000    8.047    8.047 strings_buf_filled_with.py:90(main)
        2    2.636    1.318    8.046    4.023 strings_buf_filled_with.py:15(buf_filled_with)
  1048576    5.271    0.000    5.271    0.000 {method 'count' of 'str' objects}
        1    0.001    0.001    5.191    5.191 strings_buf_filled_with.py:34(extract_ascii_strings)
        1    0.000    0.000    2.856    2.856 strings_buf_filled_with.py:61(extract_unicode_strings)
2097660/2097656    0.140    0.000    0.140    0.000 {len}
```

**please perform code review carefully and help me to improve these**

relevant issues: #205 #222 