### PR TITLE
plugin to identify suspicious mov instructions

### DIFF
--- a/floss/identification_manager.py
+++ b/floss/identification_manager.py
@@ -13,13 +13,14 @@ class IdentificationManager(viv_utils.LoggingObject):
     # negative values mark functions as not-decoding routines
     PLUGIN_WEIGHTS = {"XORPlugin": 0.5,
                       "ShiftPlugin": 0.5,
+                      "MovPlugin": 0.3,
                       "FunctionCrossReferencesToPlugin": 0.2,
                       "FunctionArgumentCountPlugin": 0.2,
-                      "FunctionIsThunkPlugin": -1.0,
                       "FunctionBlockCountPlugin": 0.025,
                       "FunctionInstructionCountPlugin": 0.025,
                       "FunctionSizePlugin": 0.025,
                       "FunctionRecursivePlugin": 0.025,
+                      "FunctionIsThunkPlugin": -1.0,
                       "FunctionIsLibraryPlugin": -1.0, }
 
     def __init__(self, vw):

--- a/floss/main.py
+++ b/floss/main.py
@@ -21,6 +21,7 @@ import plugins.arithmetic_plugin
 import identification_manager as im
 import plugins.library_function_plugin
 import plugins.function_meta_data_plugin
+import plugins.mov_plugin
 from interfaces import DecodingRoutineIdentifier
 from decoding_manager import LocationType
 from base64 import b64encode
@@ -106,6 +107,7 @@ def get_all_plugins():
         ps.append(plugins.library_function_plugin.FunctionIsLibraryPlugin())
         ps.append(plugins.arithmetic_plugin.XORPlugin())
         ps.append(plugins.arithmetic_plugin.ShiftPlugin())
+        ps.append(plugins.mov_plugin.MOVPlugin())
     return ps
 
 

--- a/floss/plugins/mov_plugin.py
+++ b/floss/plugins/mov_plugin.py
@@ -1,0 +1,46 @@
+import envi
+import viv_utils
+
+import plugin_object
+import floss.interfaces as interfaces
+
+
+class MovPlugin(plugin_object.GeneralPlugin):
+    """
+    Identify suspicious MOV instructions.
+    """
+    implements = [interfaces.DecodingRoutineIdentifier]
+    version = 1.0
+
+    def identify(self, vivisect_workspace, function_vas):
+        candidate_functions = {}
+        # walk over every instruction
+        for fva in function_vas:
+            f = viv_utils.Function(vivisect_workspace, fva)
+            for n_bb in xrange(0, len(f.basic_blocks)):
+                bb = f.basic_blocks[n_bb]
+                try:
+                    instructions = bb.instructions
+                    for n_instr in xrange(0, len(bb.instructions)):
+                        i = instructions[n_instr]
+                        # TODO other identification features: rep movs?, movs from memory to register, e.g. movsx eax, byte ptr [ecx+eax]
+                        # identify register dereferenced writes to memory, e.g. mov [eax], cl
+                        if i.mnem == "mov":
+                            op0, op1 = i.opers
+                            # ignore instruction if second operand is an immediate value
+                            # TODO use op0.isDeref() instead?
+                            if isinstance(op0, envi.archs.i386.disasm.i386RegMemOper) and not op1.isImmed():
+                                # TODO what about movs of words, dwords, qwords?
+                                # TODO handle dereferences with displacements?
+                                if op0.tsize == 1 and op0.disp == 0:
+                                    self.d("suspicious MOV instruction at 0x%08X in function 0x%08X: %s", i.va, fva, i)
+                                    # TODO add values if multiple such instructions in same function?
+                                    candidate_functions[fva] = 1.0
+                except envi.InvalidInstruction:
+                    self.w("Invalid instruction encountered in basic block, skipping: 0x%x", bb.va)  # TODO log warning?
+                    continue
+        return candidate_functions
+
+    def score(self, function_vas, vivisect_workspace=None):
+        self.d("found suspicious MOV instructions in %d functions", len(function_vas))
+        return function_vas  # scoring simply means identifying functions with suspicious instructions

--- a/floss/plugins/mov_plugin.py
+++ b/floss/plugins/mov_plugin.py
@@ -17,12 +17,9 @@ class MovPlugin(plugin_object.GeneralPlugin):
         # walk over every instruction
         for fva in function_vas:
             f = viv_utils.Function(vivisect_workspace, fva)
-            for n_bb in xrange(0, len(f.basic_blocks)):
-                bb = f.basic_blocks[n_bb]
+            for bb in f.basic_blocks:
                 try:
-                    instructions = bb.instructions
-                    for n_instr in xrange(0, len(bb.instructions)):
-                        i = instructions[n_instr]
+                    for i in bb.instructions:
                         # TODO other identification features: rep movs?, movs from memory to register, e.g. movsx eax, byte ptr [ecx+eax]
                         # identify register dereferenced writes to memory, e.g. mov [eax], cl
                         if i.mnem == "mov":

--- a/tests/src/decode-substitution-cipher/test.yml
+++ b/tests/src/decode-substitution-cipher/test.yml
@@ -27,6 +27,5 @@ Build instructions (Cross compile for Windows on Linux): |
     i686-w64-mingw32-clang test-decode-substitution-cipher.c -o bin/test-decode-substitution-cipher.exe
 
 Xfail:
-    - all
     - Linux-32bit
 


### PR DESCRIPTION
Identifies functions with register dereferenced writes to memory, e.g. `mov [eax], cl`

Testing this has shown good results. I like that it's so simple.

I think this approach has more potential (see all the TODO comments in the plugin).

Among other things this closes #202 and #203.