### PR TITLE
appveyor: attempt to build and dist 32 and 64bit archs

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -23,6 +23,9 @@ build: off
 
 artifacts:
     - path: "dist\\floss.exe"
+    - path: "dist\\floss%ARCH%.exe"
+    - path: "dist\\floss32.exe"
+    - path: "dist\\floss64.exe"
 
 deploy:
   - provider: S3

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -19,7 +19,7 @@ install:
 build: off
 
 artifacts:
-    - path: "dist\\floss.exe"
+    - path: "dist\\%PYTHON_ARCH%\\floss.exe"
 
 deploy:
   - provider: S3

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -4,7 +4,9 @@ clone_depth: 2
 environment:
     matrix:
         - PYTHON: "C:\\Python27"
+          ARCH: "32"
         - PYTHON: "C:\\Python27-x64"
+          ARCH: "64"
 
 init:
 
@@ -15,6 +17,7 @@ install:
     - ps: Set-Content "floss\\version.py" ( "__version__ = '{0}'" -f ( git describe --tags --always ) )
     - "%PYTHON%\\Scripts\\pip install -e ."
     - "%PYTHON%\\Scripts\\pyinstaller floss.spec"
+    - "move dist\\floss.exe dist\\floss.exe"
 
 build: off
 
@@ -28,6 +31,6 @@ deploy:
     secret_access_key:
       secure: nP7uNhSUZZwamVfsS80Z+gBbMjSvAvYG/avK6pTKtH78jBcKeyfKFZSTM+siO6os
     bucket: build-artifacts.floss.flare.fireeye.com
-    folder: appveyor\\%PYTHON_ARCH%
+    folder: appveyor\\%ARCH
     #artifact:
     set_public: false

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -31,6 +31,6 @@ deploy:
     secret_access_key:
       secure: nP7uNhSUZZwamVfsS80Z+gBbMjSvAvYG/avK6pTKtH78jBcKeyfKFZSTM+siO6os
     bucket: build-artifacts.floss.flare.fireeye.com
-    folder: appveyor\\%ARCH
+    folder: appveyor/%ARCH%
     #artifact:
     set_public: false

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -17,7 +17,7 @@ install:
     - ps: Set-Content "floss\\version.py" ( "__version__ = '{0}'" -f ( git describe --tags --always ) )
     - "%PYTHON%\\Scripts\\pip install -e ."
     - "%PYTHON%\\Scripts\\pyinstaller floss.spec"
-    - "move dist\\floss.exe dist\\floss.exe"
+    - "move dist\\floss.exe dist\\floss%ARCH%.exe"
 
 build: off
 
@@ -31,6 +31,6 @@ deploy:
     secret_access_key:
       secure: nP7uNhSUZZwamVfsS80Z+gBbMjSvAvYG/avK6pTKtH78jBcKeyfKFZSTM+siO6os
     bucket: build-artifacts.floss.flare.fireeye.com
-    folder: appveyor/%ARCH%
+    folder: appveyor
     #artifact:
     set_public: false

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -19,7 +19,7 @@ install:
 build: off
 
 artifacts:
-    - path: "dist\\%PYTHON_ARCH%\\floss.exe"
+    - path: "dist\\floss.exe"
 
 deploy:
   - provider: S3
@@ -28,6 +28,6 @@ deploy:
     secret_access_key:
       secure: nP7uNhSUZZwamVfsS80Z+gBbMjSvAvYG/avK6pTKtH78jBcKeyfKFZSTM+siO6os
     bucket: build-artifacts.floss.flare.fireeye.com
-    folder: appveyor
+    folder: "appveyor\\%PYTHON_ARCH%"
     #artifact:
     set_public: false

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -28,6 +28,6 @@ deploy:
     secret_access_key:
       secure: nP7uNhSUZZwamVfsS80Z+gBbMjSvAvYG/avK6pTKtH78jBcKeyfKFZSTM+siO6os
     bucket: build-artifacts.floss.flare.fireeye.com
-    folder: "appveyor\\%PYTHON_ARCH%"
+    folder: appveyor\\%PYTHON_ARCH%
     #artifact:
     set_public: false


### PR DESCRIPTION
*should* be able to use env variable `PYTHON_ARCH` to fetch current architecture. ref: https://github.com/ogrisel/python-appveyor-demo/blob/master/appveyor.yml#L18