### PR TITLE
setup: include plugins as src

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -34,9 +34,9 @@ setup(
     url='https://www.github.com/fireeye/flare-floss',
     packages=[
         'floss',
+        'floss.plugins',
     ],
     package_dir={'floss': 'floss'},
-    package_data={'floss': ['plugins/*.py']},
     entry_points={
         "console_scripts": [
             "floss=floss.main:main",


### PR DESCRIPTION
pyinstaller seems to handle the existing setup ok, but devpi-client fails to package the plugin directory. since we're not using real dynamic plugins anymore, lets include the plugins directory as source.