### PR TITLE
filter out long strings

### DIFF
--- a/floss/string_decoder.py
+++ b/floss/string_decoder.py
@@ -13,6 +13,9 @@ from decoding_manager import DecodedString, LocationType
 floss_logger = logging.getLogger("floss")
 
 
+MAX_STRING_LENGTH = 2048
+
+
 def memdiff_search(bytes1, bytes2):
     '''
     Use binary searching to find the offset of the first difference
@@ -220,12 +223,12 @@ def extract_strings(b):
     # which come from vivisect uninitialized taint tracking
     filter = re.compile("^p?V?A+$")
     for s in strings.extract_ascii_strings(b.s):
-        if filter.match(s.s):
+        if filter.match(s.s) or len(s.s) > MAX_STRING_LENGTH:
             continue
         ret.append(DecodedString(b.va + s.offset, s.s, b.decoded_at_va,
                                  b.fva, b.characteristics))
     for s in strings.extract_unicode_strings(b.s):
-        if filter.match(s.s):
+        if filter.match(s.s) or len(s.s) > MAX_STRING_LENGTH:
             continue
         ret.append(DecodedString(b.va + s.offset, s.s, b.decoded_at_va,
                                  b.fva, b.characteristics))


### PR DESCRIPTION
I propose this sanity check to filter out strings longer than `MAX_STRING_LENGTH`. I think 95% of decoded strings should be less than 100 characters anyway. So, `MAX_STRING_LENGTH = 2048` is a very generous margin. We could even lower the boundary, if you agree.
This is a quick fix for cases when emulation goes out of control.