### PR TITLE
Filter FP strings

### DIFF
--- a/doc/usage.md
+++ b/doc/usage.md
@@ -134,6 +134,15 @@ and number of discovered functions. In conjunction with the `-f` or
 functions.
 
 
+### Do not filter deobfuscated strings (`--no-filter`)
+
+The FLOSS emulation process can result in many false positive deobfuscated
+strings. By default, various filters are applied to remove most strings
+stemming from vivisect's memory initializations as well as taint and pointer
+handling, among other things. Use the `--no-filter` option to obtain the
+raw and unfiltered deobfuscated strings.
+
+
 ### Generate annotation scripts (`-i`, `-r`, and `--x64dbg`)
 
 FLOSS can generate an IDA Pro Python script that will

--- a/floss/main.py
+++ b/floss/main.py
@@ -696,7 +696,7 @@ def print_stack_strings(extracted_strings, quiet=False, expert=False):
     :param quiet: print strings only, suppresses headers
     :param expert: expert mode
     """
-    count = len(extracted_strings)
+    count = len(list(extracted_strings))
 
     if not quiet:
         print("\nFLOSS extracted %d stackstrings" % (count))
@@ -849,7 +849,7 @@ def main(argv=None):
         floss_logger.info("Extracting stackstrings...")
         stack_strings = stackstrings.extract_stackstrings(vw, selected_functions, min_length, options.no_filter)
         if not options.expert:
-            stack_strings = list(set(stack_strings))
+            stack_strings = set(stack_strings)
         print_stack_strings(stack_strings, quiet=options.quiet, expert=options.expert)
     else:
         stack_strings = []

--- a/floss/main.py
+++ b/floss/main.py
@@ -55,17 +55,17 @@ def hex(i):
     return "0x%X" % (i)
 
 
-def decode_strings(vw, function_index, decoding_functions_candidates, min_length, no_filter=False):
+def decode_strings(vw, decoding_functions_candidates, min_length, no_filter=False):
     """
     FLOSS string decoding algorithm
     :param vw: vivisect workspace
-    :param function_index: function data
     :param decoding_functions_candidates: identification manager
     :param min_length: minimum string length
     :param no_filter: do not filter decoded strings
     :return: list of decoded strings ([DecodedString])
     """
     decoded_strings = []
+    function_index = viv_utils.InstructionFunctionIndex(vw)
     # TODO pass function list instead of identification manager
     for fva, _ in decoding_functions_candidates.get_top_candidate_functions(10):
         for ctx in string_decoder.extract_decoding_contexts(vw, fva):
@@ -838,8 +838,7 @@ def main(argv=None):
             print_identification_results(sample_file_path, decoding_functions_candidates)
 
         floss_logger.info("Decoding strings...")
-        function_index = viv_utils.InstructionFunctionIndex(vw)
-        decoded_strings = decode_strings(vw, function_index, decoding_functions_candidates, min_length, options.no_filter)
+        decoded_strings = decode_strings(vw, decoding_functions_candidates, min_length, options.no_filter)
         if not options.expert:
             decoded_strings = filter_unique_decoded(decoded_strings)
         print_decoding_results(decoded_strings, options.group_functions, quiet=options.quiet, expert=options.expert)

--- a/floss/main.py
+++ b/floss/main.py
@@ -46,6 +46,7 @@ MIN_STRING_LENGTH_DEFAULT = 4
 class LoadNotSupportedError(Exception):
     pass
 
+
 class WorkspaceLoadError(Exception):
     pass
 

--- a/floss/stackstrings.py
+++ b/floss/stackstrings.py
@@ -206,23 +206,39 @@ def extract_stackstrings(vw, selected_functions):
         for ctx in extract_call_contexts(vw, fva, bb_ends):
             logger.debug('extracting stackstrings at checkpoint: 0x%x stacksize: 0x%x', ctx.pc, ctx.init_sp - ctx.sp)
             for s in strings.extract_ascii_strings(ctx.stack_memory):
-                if FP_FILTER.match(s.s):
-                    # ignore strings like: pVA, pVAAA, AAAA
-                    # which come from vivisect uninitialized taint tracking
+                try:
+                    s_stripped = filter_string(s.s)
+                except StringIsFPError:
                     continue
-                s_stripped = re.sub(FP_FILTER_SUB, "", s.s)
                 if s_stripped not in seen:
                     frame_offset = (ctx.init_sp - ctx.sp) - s.offset - getPointerSize(vw)
                     yield(StackString(fva, s_stripped, ctx.pc, ctx.sp, ctx.init_sp, s.offset, frame_offset))
                     seen.add(s_stripped)
             for s in strings.extract_unicode_strings(ctx.stack_memory):
-                if FP_FILTER.match(s.s):
-                    # ignore strings like: pVA, pVAAA, AAAA
-                    # which come from vivisect uninitialized taint tracking
+                try:
+                    s_stripped = filter_string(s.s)
+                except StringIsFPError:
                     continue
-                s_stripped = re.sub(FP_FILTER_SUB, "", s.s)
                 if s_stripped not in seen:
                     frame_offset = (ctx.init_sp - ctx.sp) - s.offset - getPointerSize(vw)
                     yield(StackString(fva, s_stripped, ctx.pc, ctx.sp, ctx.init_sp, s.offset, frame_offset))
                     seen.add(s_stripped)
 
+
+class StringIsFPError(Exception):
+    pass
+
+
+def filter_string(s):
+    """
+    Return string stripped from false positive (FP) pre- or suffixes like pVA. Raise exception if string
+    matches a well-known FP pattern.
+    :param s: input string
+    :return: string stripped from FP pre- or suffixes
+    """
+    if FP_FILTER.match(s):
+        # ignore strings like: pVA, pVAAA, AAAA
+        # which come from vivisect uninitialized taint tracking
+        raise StringIsFPError
+    s_stripped = re.sub(FP_FILTER_SUB, "", s)
+    return s_stripped

--- a/floss/stackstrings.py
+++ b/floss/stackstrings.py
@@ -173,8 +173,9 @@ def getPointerSize(vw):
         raise NotImplementedError("unexpected architecture: %s" % (vw.arch.__class__.__name__))
 
 
-FP_FILTER = re.compile("^p?V?A+$")
+FP_FILTER = re.compile("^p?V?A+$") # ignore strings like: pVA, pVAAA, AAAA which come from vivisect uninitialized taint tracking
 FP_FILTER_SUB = re.compile("^p?VA")  # remove string prefixes: pVA, VA
+FP_FILTER_CHARS = re.compile(".*(AAA|BBB|CCC|DDD|EEE|FFF|@@@).*")
 
 
 def get_basic_block_ends(vw):
@@ -236,9 +237,7 @@ def filter_string(s):
     :param s: input string
     :return: string stripped from FP pre- or suffixes
     """
-    if FP_FILTER.match(s):
-        # ignore strings like: pVA, pVAAA, AAAA
-        # which come from vivisect uninitialized taint tracking
+    if FP_FILTER.match(s) or FP_FILTER_CHARS.match(s):
         raise StringIsFPError
     s_stripped = re.sub(FP_FILTER_SUB, "", s)
     return s_stripped

--- a/floss/stackstrings.py
+++ b/floss/stackstrings.py
@@ -186,14 +186,15 @@ def get_basic_block_ends(vw):
     return index
 
 
-def extract_stackstrings(vw, selected_functions, no_filter=False):
+def extract_stackstrings(vw, selected_functions, min_length, no_filter=False):
     '''
     Extracts the stackstrings from functions in the given workspace.
 
     :param vw: The vivisect workspace from which to extract stackstrings.
-    :rtype: Generator[StackString]
     :param selected_functions: list of selected functions
+    :param min_length: minimum string length
     :param no_filter: do not filter deobfuscated stackstrings
+    :rtype: Generator[StackString]
     '''
     logger.debug('extracting stackstrings from %d functions', len(selected_functions))
     bb_ends = get_basic_block_ends(vw)
@@ -213,7 +214,7 @@ def extract_stackstrings(vw, selected_functions, no_filter=False):
                 else:
                     continue
 
-                if decoded_string not in seen:
+                if decoded_string not in seen and len(decoded_string) >= min_length:
                     frame_offset = (ctx.init_sp - ctx.sp) - s.offset - getPointerSize(vw)
                     yield(StackString(fva, decoded_string, ctx.pc, ctx.sp, ctx.init_sp, s.offset, frame_offset))
                     seen.add(decoded_string)
@@ -228,7 +229,7 @@ def extract_stackstrings(vw, selected_functions, no_filter=False):
                 else:
                     continue
 
-                if decoded_string not in seen:
+                if decoded_string not in seen and len(decoded_string) >= min_length:
                     frame_offset = (ctx.init_sp - ctx.sp) - s.offset - getPointerSize(vw)
                     yield(StackString(fva, decoded_string, ctx.pc, ctx.sp, ctx.init_sp, s.offset, frame_offset))
                     seen.add(decoded_string)

--- a/floss/string_decoder.py
+++ b/floss/string_decoder.py
@@ -5,15 +5,12 @@ import logging
 
 import strings
 import decoding_manager
-from utils import makeEmulator, is_fp_string, strip_string
+from utils import makeEmulator, is_fp_string, strip_string, MAX_STRING_LENGTH
 from function_argument_getter import get_function_contexts
 from decoding_manager import DecodedString, LocationType
 
 
 floss_logger = logging.getLogger("floss")
-
-
-MAX_STRING_LENGTH = 2048
 
 
 def memdiff_search(bytes1, bytes2):
@@ -208,7 +205,7 @@ def extract_delta_bytes(delta, decoded_at_va, source_fva=0x0):
     return delta_bytes
 
 
-def extract_strings(b):
+def extract_strings(b, no_filter):
     '''
     Extract the ASCII and UTF-16 strings from a bytestring.
 
@@ -216,19 +213,32 @@ def extract_strings(b):
     :param b: The data from which to extract the strings. Note its a
       DecodedString instance that tracks extra metadata beyond the
       bytestring contents.
+    :param no_filter: do not filter decoded strings
     :rtype: Sequence[decoding_manager.DecodedString]
     '''
     ret = []
     for s in strings.extract_ascii_strings(b.s):
-        if is_fp_string(s.s) or len(s.s) > MAX_STRING_LENGTH:
+        if len(s.s) > MAX_STRING_LENGTH:
             continue
-        s_stripped = strip_string(s.s)
-        ret.append(DecodedString(b.va + s.offset, s_stripped, b.decoded_at_va,
-                                 b.fva, b.characteristics))
+
+        if no_filter:
+            decoded_string = s.s
+        elif not is_fp_string(s.s):
+            decoded_string = strip_string(s.s)
+        else:
+            continue
+
+        ret.append(DecodedString(b.va + s.offset, decoded_string, b.decoded_at_va, b.fva, b.characteristics))
     for s in strings.extract_unicode_strings(b.s):
-        if is_fp_string(s.s) or len(s.s) > MAX_STRING_LENGTH:
+        if len(s.s) > MAX_STRING_LENGTH:
             continue
-        s_stripped = strip_string(s.s)
-        ret.append(DecodedString(b.va + s.offset, s_stripped, b.decoded_at_va,
-                                 b.fva, b.characteristics))
+
+        if no_filter:
+            decoded_string = s.s
+        elif not is_fp_string(s.s):
+            decoded_string = strip_string(s.s)
+        else:
+            continue
+
+        ret.append(DecodedString(b.va + s.offset, decoded_string, b.decoded_at_va, b.fva, b.characteristics))
     return ret

--- a/floss/string_decoder.py
+++ b/floss/string_decoder.py
@@ -5,7 +5,7 @@ import logging
 
 import strings
 import decoding_manager
-from utils import makeEmulator
+from utils import makeEmulator, is_fp_string, strip_string
 from function_argument_getter import get_function_contexts
 from decoding_manager import DecodedString, LocationType
 
@@ -219,17 +219,16 @@ def extract_strings(b):
     :rtype: Sequence[decoding_manager.DecodedString]
     '''
     ret = []
-    # ignore strings like: pVA, pVAAA, AAAA
-    # which come from vivisect uninitialized taint tracking
-    filter = re.compile("^p?V?A+$")
     for s in strings.extract_ascii_strings(b.s):
-        if filter.match(s.s) or len(s.s) > MAX_STRING_LENGTH:
+        if is_fp_string(s.s) or len(s.s) > MAX_STRING_LENGTH:
             continue
-        ret.append(DecodedString(b.va + s.offset, s.s, b.decoded_at_va,
+        s_stripped = strip_string(s.s)
+        ret.append(DecodedString(b.va + s.offset, s_stripped, b.decoded_at_va,
                                  b.fva, b.characteristics))
     for s in strings.extract_unicode_strings(b.s):
-        if filter.match(s.s) or len(s.s) > MAX_STRING_LENGTH:
+        if is_fp_string(s.s) or len(s.s) > MAX_STRING_LENGTH:
             continue
-        ret.append(DecodedString(b.va + s.offset, s.s, b.decoded_at_va,
+        s_stripped = strip_string(s.s)
+        ret.append(DecodedString(b.va + s.offset, s_stripped, b.decoded_at_va,
                                  b.fva, b.characteristics))
     return ret

--- a/floss/string_decoder.py
+++ b/floss/string_decoder.py
@@ -205,7 +205,7 @@ def extract_delta_bytes(delta, decoded_at_va, source_fva=0x0):
     return delta_bytes
 
 
-def extract_strings(b, no_filter):
+def extract_strings(b, min_length, no_filter):
     '''
     Extract the ASCII and UTF-16 strings from a bytestring.
 
@@ -213,6 +213,7 @@ def extract_strings(b, no_filter):
     :param b: The data from which to extract the strings. Note its a
       DecodedString instance that tracks extra metadata beyond the
       bytestring contents.
+    :param min_length: minimum string length
     :param no_filter: do not filter decoded strings
     :rtype: Sequence[decoding_manager.DecodedString]
     '''
@@ -228,7 +229,8 @@ def extract_strings(b, no_filter):
         else:
             continue
 
-        ret.append(DecodedString(b.va + s.offset, decoded_string, b.decoded_at_va, b.fva, b.characteristics))
+        if len(decoded_string) >= min_length:
+            ret.append(DecodedString(b.va + s.offset, decoded_string, b.decoded_at_va, b.fva, b.characteristics))
     for s in strings.extract_unicode_strings(b.s):
         if len(s.s) > MAX_STRING_LENGTH:
             continue
@@ -240,5 +242,6 @@ def extract_strings(b, no_filter):
         else:
             continue
 
-        ret.append(DecodedString(b.va + s.offset, decoded_string, b.decoded_at_va, b.fva, b.characteristics))
+        if len(decoded_string) >= min_length:
+            ret.append(DecodedString(b.va + s.offset, decoded_string, b.decoded_at_va, b.fva, b.characteristics))
     return ret

--- a/floss/utils.py
+++ b/floss/utils.py
@@ -7,6 +7,8 @@ from collections import OrderedDict
 ONE_MB = 1024 * 1024
 STACK_MEM_NAME = "[stack]"
 
+MAX_STRING_LENGTH = 2048
+
 
 def makeEmulator(vw):
     """

--- a/floss/utils.py
+++ b/floss/utils.py
@@ -79,8 +79,8 @@ def hex(i):
     return "0x%X" % (i)
 
 
-FP_FILTER_PREFIXES = re.compile(r"^.?((p|P|0)?VA)|0\\A|P?\\A|\[A")  # remove string prefixes: pVA, VA, 0VA, etc.
-FP_FILTER_SUFFIXES = re.compile(r".*[0-9A-G>]VA$")  # remove string suffixes: 0VA, AVA, >VA, etc.
+FP_FILTER_PREFIXES = re.compile(r"^.?((p|P|0)?VA)|(0|P)?\\A|\[A|P\]A|@AA")  # remove string prefixes: pVA, VA, 0VA, etc.
+FP_FILTER_SUFFIXES = re.compile(r".*([0-9A-G>]VA$|@AA)$")  # remove string suffixes: 0VA, AVA, >VA, etc.
 FP_FILTER_CHARS = re.compile(r".*(AAA|BBB|CCC|DDD|EEE|FFF|UUU|ZZZ|@@@|;;;|\?\?\?|\|\|\||    ).*")
 # alternatively: ".*([^0-9wW])\1{2}.*" to match any 3 consecutive chars (except numbers, ws, and others?)
 
@@ -99,4 +99,6 @@ def strip_string(s):
     :param s: input string
     :return: string stripped from FP pre- or suffixes
     """
-    return re.sub(FP_FILTER_PREFIXES, "", re.sub(FP_FILTER_SUFFIXES, "", s))
+    for reg in (FP_FILTER_PREFIXES, FP_FILTER_SUFFIXES):
+        s = re.sub(reg, "", s)
+    return s

--- a/floss/utils.py
+++ b/floss/utils.py
@@ -81,7 +81,7 @@ def hex(i):
 
 FP_FILTER_PREFIXES = re.compile(r"^.?((p|P|0)?VA)|(0|P)?\\A|\[A|P\]A|@AA")  # remove string prefixes: pVA, VA, 0VA, etc.
 FP_FILTER_SUFFIXES = re.compile(r".*([0-9A-G>]VA$|@AA)$")  # remove string suffixes: 0VA, AVA, >VA, etc.
-FP_FILTER_CHARS = re.compile(r".*(AAA|BBB|CCC|DDD|EEE|FFF|UUU|ZZZ|@@@|;;;|\?\?\?|\|\|\||    ).*")
+FP_FILTER_CHARS = re.compile(r".*(AAA|BBB|CCC|DDD|EEE|FFF|PPP|UUU|ZZZ|@@@|;;;|&&&|\?\?\?|\|\|\||    ).*")
 # alternatively: ".*([^0-9wW])\1{2}.*" to match any 3 consecutive chars (except numbers, ws, and others?)
 
 

--- a/floss/utils.py
+++ b/floss/utils.py
@@ -1,5 +1,6 @@
 # Copyright (C) 2017 FireEye, Inc. All Rights Reserved.
 
+import re
 import tabulate
 from collections import OrderedDict
 
@@ -76,3 +77,26 @@ def get_vivisect_meta_info(vw, selected_functions):
 
 def hex(i):
     return "0x%X" % (i)
+
+
+FP_FILTER_PREFIXES = re.compile(r"^.?((p|P|0)?VA)|0\\A|P?\\A|\[A")  # remove string prefixes: pVA, VA, 0VA, etc.
+FP_FILTER_SUFFIXES = re.compile(r".*[0-9A-G>]VA$")  # remove string suffixes: 0VA, AVA, >VA, etc.
+FP_FILTER_CHARS = re.compile(r".*(AAA|BBB|CCC|DDD|EEE|FFF|UUU|ZZZ|@@@|;;;|\?\?\?|\|\|\||    ).*")
+# alternatively: ".*([^0-9wW])\1{2}.*" to match any 3 consecutive chars (except numbers, ws, and others?)
+
+
+def is_fp_string(s):
+    """
+    Return True if string matches a well-known FP pattern.
+    :param s: input string
+    """
+    return FP_FILTER_CHARS.match(s)
+
+
+def strip_string(s):
+    """
+    Return string stripped from false positive (FP) pre- or suffixes.
+    :param s: input string
+    :return: string stripped from FP pre- or suffixes
+    """
+    return re.sub(FP_FILTER_PREFIXES, "", re.sub(FP_FILTER_SUFFIXES, "", s))

--- a/floss/utils.py
+++ b/floss/utils.py
@@ -82,7 +82,7 @@ def hex(i):
 
 
 FP_FILTER_PREFIXES = re.compile(r"^.?((p|P|0)?VA)|(0|P)?\\A|\[A|P\]A|@AA")  # remove string prefixes: pVA, VA, 0VA, etc.
-FP_FILTER_SUFFIXES = re.compile(r".*([0-9A-G>]VA$|@AA|iiVV)$")  # remove string suffixes: 0VA, AVA, >VA, etc.
+FP_FILTER_SUFFIXES = re.compile(r"([0-9A-G>]VA|@AA|iiVV|j=p@|ids@|iDC@|i4C@|i%1@)$")  # remove string suffixes: 0VA, AVA, >VA, etc.
 FP_FILTER_CHARS = re.compile(r".*(AAA|BBB|CCC|DDD|EEE|FFF|PPP|UUU|ZZZ|@@@|;;;|&&&|\?\?\?|\|\|\||    ).*")
 # alternatively: ".*([^0-9wW])\1{2}.*" to match any 3 consecutive chars (except numbers, ws, and others?)
 FP_FILTER_REP_CHARS = re.compile(r".*(.)\1{7}.*")  # any string containing the same char 8 or more consecutive times

--- a/floss/utils.py
+++ b/floss/utils.py
@@ -82,9 +82,10 @@ def hex(i):
 
 
 FP_FILTER_PREFIXES = re.compile(r"^.?((p|P|0)?VA)|(0|P)?\\A|\[A|P\]A|@AA")  # remove string prefixes: pVA, VA, 0VA, etc.
-FP_FILTER_SUFFIXES = re.compile(r".*([0-9A-G>]VA$|@AA)$")  # remove string suffixes: 0VA, AVA, >VA, etc.
+FP_FILTER_SUFFIXES = re.compile(r".*([0-9A-G>]VA$|@AA|iiVV)$")  # remove string suffixes: 0VA, AVA, >VA, etc.
 FP_FILTER_CHARS = re.compile(r".*(AAA|BBB|CCC|DDD|EEE|FFF|PPP|UUU|ZZZ|@@@|;;;|&&&|\?\?\?|\|\|\||    ).*")
 # alternatively: ".*([^0-9wW])\1{2}.*" to match any 3 consecutive chars (except numbers, ws, and others?)
+FP_FILTER_REP_CHARS = re.compile(r".*(.)\1{7}.*")  # any string containing the same char 8 or more consecutive times
 
 
 def is_fp_string(s):
@@ -92,7 +93,10 @@ def is_fp_string(s):
     Return True if string matches a well-known FP pattern.
     :param s: input string
     """
-    return FP_FILTER_CHARS.match(s)
+    for reg in (FP_FILTER_CHARS, FP_FILTER_REP_CHARS):
+        if reg.match(s):
+            return True
+    return False
 
 
 def strip_string(s):

--- a/floss/version.py
+++ b/floss/version.py
@@ -1,2 +1,2 @@
 # Copyright (C) 2017 FireEye, Inc. All Rights Reserved.
-__version__ = '1.4.0'
+__version__ = '1.5.0'

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -17,9 +17,9 @@ def extract_strings(vw):
     """
     function_index = viv_utils.InstructionFunctionIndex(vw)
     decoding_functions_candidates = identify_decoding_functions(vw)
-    decoded_strings = floss_main.decode_strings(vw, function_index, decoding_functions_candidates)
+    decoded_strings = floss_main.decode_strings(vw, function_index, decoding_functions_candidates, 4)
     selected_functions = floss_main.select_functions(vw, None)
-    decoded_stackstrings = stackstrings.extract_stackstrings(vw, selected_functions)
+    decoded_stackstrings = stackstrings.extract_stackstrings(vw, selected_functions, 4)
     decoded_strings.extend(decoded_stackstrings)
     return [ds.s for ds in decoded_strings]
 
@@ -149,4 +149,6 @@ class FLOSSTest(pytest.Item):
                 "FLOSS extraction failed:",
                 "   expected: %s" % str(expected),
                 "   got: %s" % str(got),
+                "   expected-got: %s" % str(set(expected)-set(got)),
+                "   got-expected: %s" % str(set(got) - set(expected)),
             ])

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -15,9 +15,8 @@ def extract_strings(vw):
     """
     Deobfuscate strings from vivisect workspace
     """
-    function_index = viv_utils.InstructionFunctionIndex(vw)
     decoding_functions_candidates = identify_decoding_functions(vw)
-    decoded_strings = floss_main.decode_strings(vw, function_index, decoding_functions_candidates, 4)
+    decoded_strings = floss_main.decode_strings(vw, decoding_functions_candidates, 4)
     selected_functions = floss_main.select_functions(vw, None)
     decoded_stackstrings = stackstrings.extract_stackstrings(vw, selected_functions, 4)
     decoded_strings.extend(decoded_stackstrings)


### PR DESCRIPTION
Creating this PR to open the discussion.
The goal of these filters is to reduce the FP rate. However, it is possible that we filter out true positive strings. Should we add a command-line argument to let users disable filtering (enable it by default)? We then probably should move the filtering to the print_* functions.