### PR TITLE
Add logging to script creation functions

### DIFF
--- a/floss/main.py
+++ b/floss/main.py
@@ -690,10 +690,6 @@ def create_x64dbg_database(sample_file_path, x64dbg_database_file, imagebase, de
     :param x64dbg_database_file: output file path
     :param imagebase: imagebase for target file
     :param decoded_strings: list of decoded strings ([DecodedString])
-<<<<<<< HEAD
-    :param log: controls whether to log or print the location of the x64dbg database
-=======
->>>>>>> parent of 1d71ee0... Add the option of logging messages the create script functions for consistency
     """
     script_content = create_x64dbg_database_content(sample_file_path, imagebase, decoded_strings)
     with open(x64dbg_database_file, 'wb') as f:
@@ -711,10 +707,6 @@ def create_ida_script(sample_file_path, ida_python_file, decoded_strings, stack_
     :param ida_python_file: output file path
     :param decoded_strings: list of decoded strings ([DecodedString])
     :param stack_strings: list of stack strings ([StackString])
-<<<<<<< HEAD
-    :param log: controls whether to log or print the location of the IDAPython script file
-=======
->>>>>>> parent of 1d71ee0... Add the option of logging messages the create script functions for consistency
     """
     script_content = create_ida_script_content(sample_file_path, decoded_strings, stack_strings)
     ida_python_file = os.path.abspath(ida_python_file)
@@ -734,10 +726,6 @@ def create_r2_script(sample_file_path, r2_script_file, decoded_strings, stack_st
     :param r2script_file: output file path
     :param decoded_strings: list of decoded strings ([DecodedString])
     :param stack_strings: list of stack strings ([StackString])
-<<<<<<< HEAD
-    :param log: controls whether to log or print the location of the radare2script
-=======
->>>>>>> parent of 1d71ee0... Add the option of logging messages the create script functions for consistency
     """
     script_content = create_r2_script_content(sample_file_path, decoded_strings, stack_strings)
     r2_script_file = os.path.abspath(r2_script_file)

--- a/floss/main.py
+++ b/floss/main.py
@@ -683,68 +683,68 @@ def create_r2_script_content(sample_file_path, decoded_strings, stack_strings):
     return "\n".join(main_commands)
 
 
-def create_x64dbg_database(sample_file_path, x64dbg_database_file, imagebase, decoded_strings, log=False):
+def create_x64dbg_database(sample_file_path, x64dbg_database_file, imagebase, decoded_strings):
     """
     Create an x64dbg database to annotate an executable with decoded strings.
     :param sample_file_path: input file path
     :param x64dbg_database_file: output file path
     :param imagebase: imagebase for target file
     :param decoded_strings: list of decoded strings ([DecodedString])
+<<<<<<< HEAD
     :param log: controls whether to log or print the location of the x64dbg database
+=======
+>>>>>>> parent of 1d71ee0... Add the option of logging messages the create script functions for consistency
     """
     script_content = create_x64dbg_database_content(sample_file_path, imagebase, decoded_strings)
     with open(x64dbg_database_file, 'wb') as f:
         try:
             f.write(script_content)
-            if log:
-                floss_logger.info("Wrote x64dbg database to %s\n" % x64dbg_database_file)
-            else:
-                print("Wrote x64dbg database to %s\n" % x64dbg_database_file)
+            print("Wrote x64dbg database to %s\n" % x64dbg_database_file)
         except Exception as e:
             raise e
 
 
-def create_ida_script(sample_file_path, ida_python_file, decoded_strings, stack_strings, log=False):
+def create_ida_script(sample_file_path, ida_python_file, decoded_strings, stack_strings):
     """
     Create an IDAPython script to annotate an IDB file with decoded strings.
     :param sample_file_path: input file path
     :param ida_python_file: output file path
     :param decoded_strings: list of decoded strings ([DecodedString])
     :param stack_strings: list of stack strings ([StackString])
+<<<<<<< HEAD
     :param log: controls whether to log or print the location of the IDAPython script file
+=======
+>>>>>>> parent of 1d71ee0... Add the option of logging messages the create script functions for consistency
     """
     script_content = create_ida_script_content(sample_file_path, decoded_strings, stack_strings)
     ida_python_file = os.path.abspath(ida_python_file)
     with open(ida_python_file, 'wb') as f:
         try:
             f.write(script_content)
-            if log:
-                floss_logger.info("Wrote IDAPython script file to %s\n" % ida_python_file)
-            else:
-                print("Wrote IDAPython script file to %s\n" % ida_python_file)
+            print("Wrote IDAPython script file to %s\n" % ida_python_file)
         except Exception as e:
             raise e
     # TODO return, catch exception in main()
 
 
-def create_r2_script(sample_file_path, r2_script_file, decoded_strings, stack_strings, log=False):
+def create_r2_script(sample_file_path, r2_script_file, decoded_strings, stack_strings):
     """
     Create an r2script to annotate r2 session with decoded strings.
     :param sample_file_path: input file path
     :param r2script_file: output file path
     :param decoded_strings: list of decoded strings ([DecodedString])
     :param stack_strings: list of stack strings ([StackString])
+<<<<<<< HEAD
     :param log: controls whether to log or print the location of the radare2script
+=======
+>>>>>>> parent of 1d71ee0... Add the option of logging messages the create script functions for consistency
     """
     script_content = create_r2_script_content(sample_file_path, decoded_strings, stack_strings)
     r2_script_file = os.path.abspath(r2_script_file)
     with open(r2_script_file, 'wb') as f:
         try:
             f.write(script_content)
-            if log:
-                floss_logger.info("Wrote radare2script file to %s\n" % r2_script_file)
-            else:
-                print("Wrote radare2script file to %s\n" % r2_script_file)
+            print("Wrote radare2script file to %s\n" % r2_script_file)
         except Exception as e:
             raise e
     # TODO return, catch exception in main()

--- a/floss/main.py
+++ b/floss/main.py
@@ -690,7 +690,7 @@ def create_x64dbg_database(sample_file_path, x64dbg_database_file, imagebase, de
     :param x64dbg_database_file: output file path
     :param imagebase: imagebase for target file
     :param decoded_strings: list of decoded strings ([DecodedString])
-    :param log: conrols whether to log or print the location of the x64dbg database
+    :param log: controls whether to log or print the location of the x64dbg database
     """
     script_content = create_x64dbg_database_content(sample_file_path, imagebase, decoded_strings)
     with open(x64dbg_database_file, 'wb') as f:
@@ -711,7 +711,7 @@ def create_ida_script(sample_file_path, ida_python_file, decoded_strings, stack_
     :param ida_python_file: output file path
     :param decoded_strings: list of decoded strings ([DecodedString])
     :param stack_strings: list of stack strings ([StackString])
-    :param log: conrols whether to log or print the location of the IDAPython script file
+    :param log: controls whether to log or print the location of the IDAPython script file
     """
     script_content = create_ida_script_content(sample_file_path, decoded_strings, stack_strings)
     ida_python_file = os.path.abspath(ida_python_file)
@@ -734,7 +734,7 @@ def create_r2_script(sample_file_path, r2_script_file, decoded_strings, stack_st
     :param r2script_file: output file path
     :param decoded_strings: list of decoded strings ([DecodedString])
     :param stack_strings: list of stack strings ([StackString])
-    :param log: conrols whether to log or print the location of the radare2script
+    :param log: controls whether to log or print the location of the radare2script
     """
     script_content = create_r2_script_content(sample_file_path, decoded_strings, stack_strings)
     r2_script_file = os.path.abspath(r2_script_file)

--- a/floss/main.py
+++ b/floss/main.py
@@ -699,7 +699,7 @@ def create_x64dbg_database(sample_file_path, x64dbg_database_file, imagebase, de
     with open(x64dbg_database_file, 'wb') as f:
         try:
             f.write(script_content)
-            print("Wrote x64dbg database to %s\n" % x64dbg_database_file)
+            floss_logger.info("Wrote x64dbg database to %s\n" % x64dbg_database_file)
         except Exception as e:
             raise e
 
@@ -721,7 +721,7 @@ def create_ida_script(sample_file_path, ida_python_file, decoded_strings, stack_
     with open(ida_python_file, 'wb') as f:
         try:
             f.write(script_content)
-            print("Wrote IDAPython script file to %s\n" % ida_python_file)
+            floss_logger.info("Wrote IDAPython script file to %s\n" % ida_python_file)
         except Exception as e:
             raise e
     # TODO return, catch exception in main()
@@ -744,7 +744,7 @@ def create_r2_script(sample_file_path, r2_script_file, decoded_strings, stack_st
     with open(r2_script_file, 'wb') as f:
         try:
             f.write(script_content)
-            print("Wrote radare2script file to %s\n" % r2_script_file)
+            floss_logger.info("Wrote radare2script file to %s\n" % r2_script_file)
         except Exception as e:
             raise e
     # TODO return, catch exception in main()

--- a/floss/main.py
+++ b/floss/main.py
@@ -734,7 +734,7 @@ def create_r2_script(sample_file_path, r2_script_file, decoded_strings, stack_st
     :param r2script_file: output file path
     :param decoded_strings: list of decoded strings ([DecodedString])
     :param stack_strings: list of stack strings ([StackString])
-    :param log: conrols whether to log or print the location of the eadare2script
+    :param log: conrols whether to log or print the location of the radare2script
     """
     script_content = create_r2_script_content(sample_file_path, decoded_strings, stack_strings)
     r2_script_file = os.path.abspath(r2_script_file)

--- a/floss/main.py
+++ b/floss/main.py
@@ -683,56 +683,68 @@ def create_r2_script_content(sample_file_path, decoded_strings, stack_strings):
     return "\n".join(main_commands)
 
 
-def create_x64dbg_database(sample_file_path, x64dbg_database_file, imagebase, decoded_strings):
+def create_x64dbg_database(sample_file_path, x64dbg_database_file, imagebase, decoded_strings, log=False):
     """
     Create an x64dbg database to annotate an executable with decoded strings.
     :param sample_file_path: input file path
     :param x64dbg_database_file: output file path
     :param imagebase: imagebase for target file
     :param decoded_strings: list of decoded strings ([DecodedString])
+    :param log: conrols whether to log or print the location of the x64dbg database
     """
     script_content = create_x64dbg_database_content(sample_file_path, imagebase, decoded_strings)
     with open(x64dbg_database_file, 'wb') as f:
         try:
             f.write(script_content)
-            print("Wrote x64dbg database to %s\n" % x64dbg_database_file)
+            if log:
+                floss_logger.info("Wrote x64dbg database to %s\n" % x64dbg_database_file)
+            else:
+                print("Wrote x64dbg database to %s\n" % x64dbg_database_file)
         except Exception as e:
             raise e
 
 
-def create_ida_script(sample_file_path, ida_python_file, decoded_strings, stack_strings):
+def create_ida_script(sample_file_path, ida_python_file, decoded_strings, stack_strings, log=False):
     """
     Create an IDAPython script to annotate an IDB file with decoded strings.
     :param sample_file_path: input file path
     :param ida_python_file: output file path
     :param decoded_strings: list of decoded strings ([DecodedString])
     :param stack_strings: list of stack strings ([StackString])
+    :param log: conrols whether to log or print the location of the IDAPython script file
     """
     script_content = create_ida_script_content(sample_file_path, decoded_strings, stack_strings)
     ida_python_file = os.path.abspath(ida_python_file)
     with open(ida_python_file, 'wb') as f:
         try:
             f.write(script_content)
-            print("Wrote IDAPython script file to %s\n" % ida_python_file)
+            if log:
+                floss_logger.info("Wrote IDAPython script file to %s\n" % ida_python_file)
+            else:
+                print("Wrote IDAPython script file to %s\n" % ida_python_file)
         except Exception as e:
             raise e
     # TODO return, catch exception in main()
 
 
-def create_r2_script(sample_file_path, r2_script_file, decoded_strings, stack_strings):
+def create_r2_script(sample_file_path, r2_script_file, decoded_strings, stack_strings, log=False):
     """
     Create an r2script to annotate r2 session with decoded strings.
     :param sample_file_path: input file path
     :param r2script_file: output file path
     :param decoded_strings: list of decoded strings ([DecodedString])
     :param stack_strings: list of stack strings ([StackString])
+    :param log: conrols whether to log or print the location of the eadare2script
     """
     script_content = create_r2_script_content(sample_file_path, decoded_strings, stack_strings)
     r2_script_file = os.path.abspath(r2_script_file)
     with open(r2_script_file, 'wb') as f:
         try:
             f.write(script_content)
-            print("Wrote radare2script file to %s\n" % r2_script_file)
+            if log:
+                floss_logger.info("Wrote radare2script file to %s\n" % r2_script_file)
+            else:
+                print("Wrote radare2script file to %s\n" % r2_script_file)
         except Exception as e:
             raise e
     # TODO return, catch exception in main()


### PR DESCRIPTION
As I was testing generating script files for idapro, radare2 and x64dbg, and I noticed that there was a few print() statements that were messing with my logging. Specifically, in the floss.main.create_(x64dbg/ida/r2)_database() functions. I added an optional parameter to those 3 functions, so Floss's normal behavior remains unchanged, but those who want to log everything in lieu of using print() now can.