### PR TITLE
Added an option to set the maximum number of times emulation can revisits addresses.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,7 @@ lib/
 
 # Test executables
 bin/
+
+# PyCharm
+.idea
+venv

--- a/floss/string_decoder.py
+++ b/floss/string_decoder.py
@@ -91,7 +91,7 @@ def memdiff(bytes1, bytes2):
     return diffs
 
 
-def extract_decoding_contexts(vw, function):
+def extract_decoding_contexts(vw, function, max_hits):
     '''
     Extract the CPU and memory contexts of all calls to the given function.
     Under the hood, we brute-force emulate all code paths to extract the
@@ -101,9 +101,10 @@ def extract_decoding_contexts(vw, function):
     :param vw: The vivisect workspace in which the function is defined.
     :type function: int
     :param function: The address of the function whose contexts we'll find.
+    :param max_hits: The maximum number of hits per address
     :rtype: Sequence[function_argument_getter.FunctionContext]
     '''
-    return get_function_contexts(vw, function)
+    return get_function_contexts(vw, function, max_hits)
 
 
 def emulate_decoding_routine(vw, function_index, function, context, max_instruction_count):


### PR DESCRIPTION
Added an option to set the maximum number of times emulation can revisits revisits addresses.

Increasing it improves string decoding within loops and
complex flows, but takes longer.

Also improved the string de-duplication process (still not perfect).