### PR TITLE
add option to generate simple JSON report

### DIFF
--- a/doc/usage.md
+++ b/doc/usage.md
@@ -49,6 +49,16 @@ Analogous, you can disable the extraction of obfuscated strings or stackstrings.
     floss.exe --no-stack-strings malware.bin
 
 
+### Write output as JSON (`-o/--output-json`)
+
+Use the `-o` or `--output-json` with the name of a file you want
+ the output to be written to.  The resulting report will contain
+ all the same data that was written to `stdout` but structured
+ in JSON to make it easy to ingest by a script.
+
+    floss.exe --output-json report.json malware.bin
+
+
 ### Quiet mode (`-q`)
 
 You can supress the formatting of FLOSS output by providing

--- a/floss/decoding_manager.py
+++ b/floss/decoding_manager.py
@@ -21,10 +21,10 @@ MAX_MAPS_SIZE = 1024 * 1024 * 100  # 100MB max memory allocated in an emulator i
 DecodedString = namedtuple("DecodedString", ["va", "s", "decoded_at_va", "fva", "characteristics"])
 
 
-class LocationType(Enum):
-    STACK = 1
-    GLOBAL = 2
-    HEAP = 3
+class LocationType(str, Enum):
+    STACK = 'STACK'
+    GLOBAL = 'GLOBAL'
+    HEAP = 'HEAP'
 
 
 def is_import(emu, va):

--- a/floss/main.py
+++ b/floss/main.py
@@ -850,20 +850,23 @@ def create_r2_script(sample_file_path, r2_script_file, decoded_strings, stack_st
     # TODO return, catch exception in main()
 
 
-def create_json_output(json_file_path, sample_file_path, decoded_strings, stack_strings):
+def create_json_output(options, sample_file_path, decoded_strings, stack_strings):
     """
     Create a report of the analysis performed by FLOSS
-    :param json_file_path: path to write the report
+    :param options: parsed options
     :param sample_file_path: path of the sample analyzed
     :param decoded_strings: list of decoded strings ([DecodedString])
     :param stack_strings: list of stack strings ([StackString])
     """
-    results = {'stack_strings': [sanitize_string_for_printing(ss.s) for ss in stack_strings],
+    strings = {'stack_strings': [sanitize_string_for_printing(ss.s) for ss in stack_strings],
                'decoded_strings': [sanitize_string_for_printing(ds.s) for ds in decoded_strings]}
-    report = {'file_path': sample_file_path, 'results': results}
+    metadata = {'file_path': sample_file_path,
+                'stack_strings': not options.no_stack_strings,
+                'decoded_strings': not options.no_decoded_strings,
+                'static_strings': not options.no_static_strings}
     try:
-        with open(json_file_path, 'w') as f:
-            json.dump(report, f)
+        with open(options.json_file_path, 'w') as f:
+            json.dump({'metadata': metadata, 'strings': strings}, f)
     except Exception:
         raise
 
@@ -1114,7 +1117,7 @@ def main(argv=None):
         print("\nFinished execution after %f seconds" % (time1 - time0))
 
     if options.json_output_file:
-        create_json_output(options.json_output_file, sample_file_path, decoded_strings, stack_strings)
+        create_json_output(options, sample_file_path, decoded_strings, stack_strings)
         floss_logger.info("Wrote JSON file to %s\n" % options.json_output_file)
 
     return 0

--- a/floss/main.py
+++ b/floss/main.py
@@ -868,7 +868,7 @@ def create_json_output(options, sample_file_path, decoded_strings, stack_strings
                 'static_strings': not options.no_static_strings}
     report = {'metadata': metadata, 'strings': strings}
     try:
-        with open(options.json_file_path, 'w') as f:
+        with open(options.json_output_file, 'w') as f:
             json.dump(report, f, iterable_as_array=True)
     except Exception:
         raise

--- a/floss/main.py
+++ b/floss/main.py
@@ -80,6 +80,17 @@ def decode_strings(vw, decoding_functions_candidates, min_length, no_filter=Fals
     return decoded_strings
 
 
+def sanitize_strings_iterator(str_coll):
+    """
+    Iterate a collection and yield sanitized strings (uses sanitize_string_for_printing)
+    :param str_coll: collection of strings to be sanitized
+    :return: a sanitized string
+    """
+    for s_obj in str_coll:
+        s = getattr(s_obj, 's', s_obj)  # Use .s attribute from each namedtuple if possible
+        yield sanitize_string_for_printing(s)
+
+
 def sanitize_string_for_printing(s):
     """
     Return sanitized string for printing.
@@ -861,9 +872,9 @@ def create_json_output(options, sample_file_path, decoded_strings, stack_strings
     :param stack_strings: list of stack strings ([StackString])
     :param static_strings: iterable of static strings ([String])
     """
-    strings = {'stack_strings': stack_strings,
-               'decoded_strings': decoded_strings,
-               'static_strings': static_strings}
+    strings = {'stack_strings': sanitize_strings_iterator(stack_strings),
+               'decoded_strings': sanitize_strings_iterator(decoded_strings),
+               'static_strings': sanitize_strings_iterator(static_strings)}
     metadata = {'file_path': sample_file_path,
                 'date': datetime.datetime.now().isoformat(),
                 'stack_strings': not options.no_stack_strings,

--- a/floss/main.py
+++ b/floss/main.py
@@ -859,6 +859,7 @@ def create_json_output(options, sample_file_path, decoded_strings, stack_strings
     :param sample_file_path: path of the sample analyzed
     :param decoded_strings: list of decoded strings ([DecodedString])
     :param stack_strings: list of stack strings ([StackString])
+    :param static_strings: iterable of static strings ([String])
     """
     strings = {'stack_strings': stack_strings,
                'decoded_strings': decoded_strings,

--- a/floss/main.py
+++ b/floss/main.py
@@ -8,6 +8,7 @@ import sys
 import mmap
 import string
 import logging
+import datetime
 from time import time
 from itertools import chain
 from optparse import OptionParser, OptionGroup
@@ -863,6 +864,7 @@ def create_json_output(options, sample_file_path, decoded_strings, stack_strings
                'decoded_strings': decoded_strings,
                'static_strings': static_strings}
     metadata = {'file_path': sample_file_path,
+                'date': datetime.datetime.now().isoformat(),
                 'stack_strings': not options.no_stack_strings,
                 'decoded_strings': not options.no_decoded_strings,
                 'static_strings': not options.no_static_strings}

--- a/setup.py
+++ b/setup.py
@@ -13,6 +13,7 @@ except ImportError:
 requirements = [
     "q",
     "pyyaml",
+    "simplejson",
     "tabulate",
     "vivisect",
     "plugnplay",


### PR DESCRIPTION
Add `-o`/`--output-json` option to write the results of the analysis to a file in JSON format.