### PR TITLE
Use relative path for testfiles submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "tests/data"]
 	path = tests/data
-	url = git@github.com:fireeye/flare-floss-testfiles.git
+	url = ../flare-floss-testfiles.git


### PR DESCRIPTION
With a similar rational to https://github.com/fireeye/capa/issues/255, looks to change the path for submodules from absolute (which forces a ssh based clone) to relative.

Note a downside mentioned within the issue stating that developers would need to fork the testfiles repository as well while developing.