### PR TITLE
WIP to further improve cli handling

### DIFF
--- a/doc/usage.md
+++ b/doc/usage.md
@@ -4,8 +4,8 @@
 
 You can use FLOSS just like you'd use `strings.exe`:
  to extract human readable strings from binary data.
-The enhancement that FLOSS provides is that it staticly
- analyzes exectuable files and decodes obfuscated strings.
+The enhancement that FLOSS provides is that it statically
+ analyzes executable files and decodes obfuscated strings.
 These include strings encrypted in global memory,
  deobfuscated onto the heap, or manually created on the
  stack (stackstrings).
@@ -16,8 +16,13 @@ Since FLOSS also extracts static strings (like `strings.exe`),
 Here's a summary of the command line flags and options you
  can provide to FLOSS to modify its behavior.
 
+See `floss -h` for all supported arguments and usage examples. This displays the most used arguments only.
+
+To see all supported arguments run `floss -h -x` to enable the eXpert mode.
 
 ### Extract static, obfuscated, and stack strings (default mode)
+
+    floss.exe malware.bin
 
 The default mode for FLOSS is to extract the following string types from an executable file:
 - static ASCII and UTF16LE strings
@@ -28,8 +33,6 @@ See the section on [Shellcode analysis](#shellcode) below on how to analyze raw 
 containing shellcode.
 
 By default FLOSS uses a minimum string length of four.
-
-    floss.exe malware.bin
 
 
 ### Disable string type extraction (`--no-<STRING-TYPE>-strings`)
@@ -49,19 +52,16 @@ Analogous, you can disable the extraction of obfuscated strings or stackstrings.
     floss.exe --no-stack-strings malware.bin
 
 
-### Write output as JSON (`-o/--output-json`)
+### Write output as JSON (`-j/--json`)
 
-Use the `-o` or `--output-json` with the name of a file you want
- the output to be written to.  The resulting report will contain
- all the same data that was written to `stdout` but structured
- in JSON to make it easy to ingest by a script.
+Write FLOSS results to `stdout` structured in JSON to make it easy to ingest by a script.
 
-    floss.exe --output-json report.json malware.bin
+    floss.exe -j malware.bin
 
 
-### Quiet mode (`-q`)
+### Quiet mode (`-q/--quiet`)
 
-You can supress the formatting of FLOSS output by providing
+You can suppress the formatting of FLOSS output by providing
  the flags `-q` or `--quiet`.
 These flags are appropriate if you will pipe the results of FLOSS
  into a filtering or searching program such as grep, and
@@ -72,10 +72,9 @@ The "type" of the string (static, decoded, or stackstring)
  is not included.
 
      floss.exe -q malware.bin
-     floss.exe --quiet malware.bin
 
 
-### Minimum string length (`-n`)
+### Minimum string length (`-n/--minimum-length`)
 
 By default, FLOSS searches for human-readable strings
  with a length of at least four characters.
@@ -87,29 +86,12 @@ Supplying a larger minimum length reduces the chances
  human-readable strings
 
     floss.exe -n 10 malware.bin
-    floss.exe --minimum-length=10 malware.bin
 
 
-### Group output strings (`-g`)
-
-Sometimes malware uses more than one decoding routine
- to deobfuscate different sets of strings.
-FLOSS identifies all decoding routines and prints
- their data in one invocation.
-You can instruct FLOSS to group the recovered strings
- by decoding routine (rather than RVA) using the
- `-g` or `--group` flags.
-This is useful to illustrate how malware decodes
- strings of different sensitivity.
-
-    floss.exe -g malware.bin
-    floss.exe --group malware.bin
-
-
-### Decoding function specification (`-f`)
+### Decoding function specification (`--functions`)
 
 You can instruct FLOSS to decode the strings provided
- to specific functions by using the `-f` or `--functions`
+ to specific functions by using the `--functions`
  option.
 By default, FLOSS uses heuristics to identify decoding
  routines in malware.
@@ -123,25 +105,7 @@ This can improve performance as FLOSS by perhaps one-third
   to always manually identify decoding routines).
 Specify functions by using their hex-encoded virtual address.
 
-    floss.exe -f 0x401000,0x402000 malware.bin
-    floss.exe --functions=0x401000,0x402000 malware.bin
-
-
-### Save vivisect workspace (`--save-workspace`)
-
-Save the vivisect .viv workspace file to the current directory. Run
-FLOSS on a .viv workspace file to save the time it takes to generate
-the workspace.
-
-
-### Display vivisect workspace meta information (`-m`)
-
-You can display basic meta information about the generated vivisect
-workspace using the `-m` or `--show-metainfo` option. The information
-includes details such as architecture, discovered executable surface area,
-and number of discovered functions. In conjunction with the `-f` or
-`--functions` option FLOSS will display meta information about the selected
-functions.
+    floss.exe --functions 0x401000 0x402000 malware.bin
 
 
 ### Do not filter deobfuscated strings (`--no-filter`)
@@ -153,70 +117,19 @@ handling, among other things. Use the `--no-filter` option to obtain the
 raw and unfiltered deobfuscated strings.
 
 
-### Generate annotation scripts (`-i`, `-j`, `-r`, and `--x64dbg`)
-
-FLOSS can generate an IDA Pro Python script that will
- annotate the idb database of the malware sample with
- its decoded strings.
-The script appends comments to the virtual addresses
- of the encoded data so its easy to interpet.
-Provide the option `-i` or `--ida` to instruct FLOSS to
- write the script to the specified file.
-
-    floss.exe -i myscript.py malware.bin
-    floss.exe --ida=myscript.py malware.bin
-
-To create an annotation script for Binary Ninja, use the `-j`, or `--binja` switch.
-
-    floss.exe -j myscript.py malware.bin
-    floss.exe --binja myscript.py malware.bin
-
-To create an annotation script for radare2, use the `-r`
-or `--radare` switch.
-
-    floss.exe -r myr2script malware.bin
-    floss.exe --radare=myr2script malware.bin
-
-To create a x64dbg database/json file to annotate the decoded strings
-in x64dbg, use the `--x64dbg` switch.
-
-    floss.exe --x64dbg=myx64dbgdatabase malware.bin
-
-
-### Verbose and debug modes (`-v`/`-d`)
-
-If FLOSS seems to encounter any issues, try re-running the program
- in the verbose (`-v` or `--verbose`) or debug (`-d` or
- `--debug`) modes.
-In these modes, FLOSS prints status and debugging output
- to the standard error stream.
-This provides additional context if FLOSS encounters an
- exception or appears to be running slowly.
-The verbose mode enables a moderate amount of logging output,
- while the debug mode enables a large amount of logging output.
-
-     floss.exe -v malware.bin
-     floss.exe --verbose malware.bin
-
-     floss.exe -d malware.bin
-     floss.exe --debug malware.bin
-
-
 ## <a name="shellcode"></a>Shellcode analysis options
 
-Malicious shellcode often times contains obfuscated strings and/or stackstrings.
-FLOSS can analyze raw binary files containing shellcode via the `-s` switch. All
+Malicious shellcode often times contains obfuscated strings or stackstrings.
+FLOSS can analyze raw binary files containing shellcode via the `-s/--shellcode` switch. All
 options mentioned above can also be applied when analyzing shellcode.
 
     floss.exe -s malware.bin
 
-If you want to specify a base address for the shellcode, use the the `-b` or
-`--shellcode_base` switch.
+If you want to specify a base address for the shellcode, use the `--shellcode_base` switch.
 
-    floss.exe -s malware.bin -b 0x1000000
+    floss.exe -s malware.bin --shellcode_base 0x1000000
 
-You can specify an entry point for the shellcode with the `-e` or `--shellcode_ep`
-option. The `entry point` value is the relative offset from `base` where the shellcode starts executing. Although vivisect does a good job identifying code, providing an entry point
-might improve code analysis.
+You can specify an entry point for the shellcode with the `--shellcode-entry-point`
+option. The `entry point` value is the relative offset from `base` where the shellcode starts executing. Although vivisect does a good job identifying code, providing an entry point might improve code analysis.
 
-    floss.exe -s malware.bin -b 0x1000000 -e 0x100
+    floss.exe -s malware.bin --shellcode_base 0x1000000 --shellcode-entry-point 0x100

--- a/tests/test_cli_args.py
+++ b/tests/test_cli_args.py
@@ -9,28 +9,24 @@ SCFILE = os.path.join(
 
 
 def test_functions():
-    # need both -x and --function
-    assert floss.main.main(["floss.exe", EXEFILE, "--function", "0x1111111"]) == -1
-
     # 0x1111111 is not a function
     assert floss.main.main(["floss.exe", EXEFILE, "-x", "--function", "0x1111111"]) == -1
 
     # ok
     assert floss.main.main(["floss.exe", EXEFILE, "-x", "--function", "0x401560"]) == 0
-    assert floss.main.main(["floss.exe", EXEFILE, "-x", "--function", "0x401560", "0x401000"]) == 0
+    assert floss.main.main(["floss.exe", EXEFILE, "--function", "0x401560"]) == 0
+    assert floss.main.main(["floss.exe", EXEFILE, "--function", "0x401560", "0x401000"]) == 0
 
 
 def test_shellcode():
-    # need both -x and --shellcode
-    assert floss.main.main(["floss.exe", SCFILE, "--shellcode"]) == -1
-
     # ok
     assert floss.main.main(["floss.exe", SCFILE, "-x", "--shellcode"]) == 0
-    assert floss.main.main(["floss.exe", SCFILE, "-x", "--shellcode", "--shellcode-base", "0x2000"]) == 0
-    assert floss.main.main(["floss.exe", SCFILE, "-x", "--shellcode", "--shellcode-entry-point", "0x1001"]) == 0
+    assert floss.main.main(["floss.exe", SCFILE, "--shellcode"]) == 0
+    assert floss.main.main(["floss.exe", SCFILE, "--shellcode", "--shellcode-base", "0x2000"]) == 0
+    assert floss.main.main(["floss.exe", SCFILE, "--shellcode", "--shellcode-entry-point", "0x1001"]) == 0
 
     # arch should be i386 or amd64
     # and will autodetect
-    assert floss.main.main(["floss.exe", SCFILE, "-x", "--shellcode", "--shellcode-arch", "aarch64"]) == -1
-    assert floss.main.main(["floss.exe", SCFILE, "-x", "--shellcode", "--shellcode-arch", "i386"]) == 0
-    assert floss.main.main(["floss.exe", SCFILE, "-x", "--shellcode", "--shellcode-arch", "amd64"]) == 0
+    assert floss.main.main(["floss.exe", SCFILE, "--shellcode", "--shellcode-arch", "aarch64"]) == -1
+    assert floss.main.main(["floss.exe", SCFILE, "--shellcode", "--shellcode-arch", "i386"]) == 0
+    assert floss.main.main(["floss.exe", SCFILE, "--shellcode", "--shellcode-arch", "amd64"]) == 0


### PR DESCRIPTION
Continuing to use the `-x` option to enable advanced options.

With these changes it's possible to use the advanced options without specifying `-x` all the time.

```
$ floss -h
usage: floss [-h] [-x] [-j] [-v] [-vv] [--color {auto,always,never}] [-d] [-q] [-s] sample

The FLARE team's open-source tool to extract obfuscated strings from malware.
  floss 2.0.0-rc1 - https://github.com/fireeye/flare-floss/

positional arguments:
  sample                path to sample to analyze

optional arguments:
  -h, --help            show this help message and exit
  -x                    enable eXpert arguments, see `floss --help -x`

rendering arguments:
  -j, --json            emit JSON instead of text
  -v, --verbose         enable verbose result document (no effect with --json)
  -vv, --vverbose       enable very verbose result document (no effect with --json)
  --color {auto,always,never}
                        enable ANSI color codes in results, default: only during interactive session

logging arguments:
  -d, --debug           enable debugging output on STDERR
  -q, --quiet           disable all status output except fatal errors

shellcode arguments:
  -s, --shellcode       analyze shellcode

only displaying core arguments, run `floss --help -x` to see all supported arguments

examples:
  extract all strings from an executable
    floss suspicious.exe

  extract all strings from shellcode
    floss -s shellcode.bin

```

```
$ floss -h -x
usage: floss [-h] [-x] [-j] [-v] [-vv] [--color {auto,always,never}] [-d] [-q] [-n MIN_LENGTH] [--functions [FUNCTIONS [FUNCTIONS ...]]] [--no-filter] [--max-instruction-count MAX_INSTRUCTION_COUNT]
             [--max-address-revisits MAX_ADDRESS_REVISITS] [--no-static-strings] [--no-decoded-strings] [--no-stack-strings] [-s] [--shellcode-entry-point SHELLCODE_ENTRY_POINT] [--shellcode-base SHELLCODE_BASE]
             [--shellcode-arch {i386,amd64}]
             sample

The FLARE team's open-source tool to extract obfuscated strings from malware.
  floss 2.0.0-rc1 - https://github.com/fireeye/flare-floss/

positional arguments:
  sample                path to sample to analyze

optional arguments:
  -h, --help            show this help message and exit
  -x                    enable eXpert arguments, see `floss --help -x`

rendering arguments:
  -j, --json            emit JSON instead of text
  -v, --verbose         enable verbose result document (no effect with --json)
  -vv, --vverbose       enable very verbose result document (no effect with --json)
  --color {auto,always,never}
                        enable ANSI color codes in results, default: only during interactive session

logging arguments:
  -d, --debug           enable debugging output on STDERR
  -q, --quiet           disable all status output except fatal errors

analysis arguments:
  -n MIN_LENGTH, --minimum-length MIN_LENGTH
                        minimum string length
  --functions [FUNCTIONS [FUNCTIONS ...]]
                        only analyze the specified functions, hex-encoded, like 0x401000
  --no-filter           do not filter deobfuscated strings (may result in many false positive strings)
  --max-instruction-count MAX_INSTRUCTION_COUNT
                        maximum number of instructions to emulate per function
  --max-address-revisits MAX_ADDRESS_REVISITS
                        maximum number of address revisits per function
  --no-static-strings   do not show static ASCII and UTF-16 strings
  --no-decoded-strings  do not show decoded strings
  --no-stack-strings    do not show stackstrings

shellcode arguments:
  -s, --shellcode       analyze shellcode
  --shellcode-entry-point SHELLCODE_ENTRY_POINT
                        shellcode entry point, hex-encoded like 0x401000
  --shellcode-base SHELLCODE_BASE
                        shellcode base offset, hex-encoded like 0x401000
  --shellcode-arch {i386,amd64}
                        shellcode architecture, default: autodetect

examples:
  only show strings of minimun length 6
    floss -n 6 suspicious.exe

  only show stack strings
    floss --no-static-strings --no-decoded-strings suspicious.exe

```

ref: #328