### PR TITLE
Fixed rendering issue for Stack, Tight, and Decoded strings without -v flag #655

### DIFF
--- a/floss/render/default.py
+++ b/floss/render/default.py
@@ -131,15 +131,15 @@ def strtime(seconds):
     return f"{m:02.0f}:{s:02.0f}"
 
 
-def print_static_strings(strings, encoding, offset_len, ostream, verbose, disable_headers):
+def render_static_substrings(strings, encoding, offset_len, ostream, verbose, disable_headers):
     if verbose != Verbosity.DEFAULT:
         encoding = heading_style(encoding)
     render_sub_heading(f"FLOSS STATIC STRINGS: {encoding}", len(strings), ostream, disable_headers)
     for s in strings:
-        colored_string = string_style(s.string)
         if verbose == Verbosity.DEFAULT:
             ostream.writeln(s.string)
         else:
+            colored_string = string_style(s.string)
             ostream.writeln(f"0x{s.offset:>0{offset_len}x} {colored_string}")
     ostream.writeln("")
 
@@ -158,8 +158,8 @@ def render_staticstrings(strings, ostream, verbose, disable_headers):
         unicode_offset_len = len(f"{unicode_strings[-1].offset}")
     offset_len = max(ascii_offset_len, unicode_offset_len)
 
-    print_static_strings(ascii_strings, "ASCII", offset_len, ostream, verbose, disable_headers)
-    print_static_strings(unicode_strings, "UTF-16LE", offset_len, ostream, verbose, disable_headers)
+    render_static_substrings(ascii_strings, "ASCII", offset_len, ostream, verbose, disable_headers)
+    render_static_substrings(unicode_strings, "UTF-16LE", offset_len, ostream, verbose, disable_headers)
 
 
 def render_stackstrings(


### PR DESCRIPTION
Changes:-

- No colors render when not in verbose view
- Resolved the issue of the colors appearing too bright

Screenshots:- 
On Ubuntu -> 
<p float="left">
<img width="50%" src="https://user-images.githubusercontent.com/94680887/225609412-ff0bcd77-6f40-4344-ab3a-dda58a6de20d.png">
<img width="49%" src="https://user-images.githubusercontent.com/94680887/225609449-cdc98083-57a7-4fd6-90ba-93cf59f8f107.png">
</p>
On Windows ->
<p float="left">
<img width="50%" src="https://user-images.githubusercontent.com/94680887/225701937-7c5ee203-5dc2-44ef-ba48-1aa117591dc6.png">
<img width="49%" src="https://user-images.githubusercontent.com/94680887/225700826-674e1b4c-ce6d-4402-b686-dba5056aeb86.png">
</p>

Notice the slight difference in color appearance when using this feature on Windows vs Ubuntu dark mode. Color rendering may vary depending on the operating system and display settings.

Looking forward to hearing your thoughts and suggestions :)

