### PR TITLE
Utilize rich "soft_wrap" feature for Improved Display

### DIFF
--- a/floss/render/default.py
+++ b/floss/render/default.py
@@ -9,7 +9,7 @@ from typing import Dict, List, Tuple, Union
 from rich import box
 from rich.table import Table
 from rich.markup import escape
-from enrich.console import Console
+from rich.console import Console
 
 import floss.utils as util
 import floss.logging_
@@ -301,7 +301,7 @@ def get_color(color):
 
 def render(results: floss.results.ResultDocument, verbose, disable_headers, color):
     sys.__stdout__.reconfigure(encoding="utf-8")
-    console = Console(file=io.StringIO(), color_system=get_color(color), highlight=False, redirect=False)
+    console = Console(file=io.StringIO(), color_system=get_color(color), highlight=False, soft_wrap=True)
 
     if not disable_headers:
         console.print("\n")

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,6 @@ requirements = [
     "halo==0.0.31",
     "rich==13.4.2",
     "pefile>=2022.5.30",
-    "enrich==1.2.7",
 ]
 
 # this sets __version__


### PR DESCRIPTION
We can leverage the `rich` library's `soft_wrap` feature, which neatly handles line breaks while maintaining the string's integrity.

Reference:- https://github.com/pycontribs/enrich

Fixes:- #826 