### PR TITLE
Add num_api_calls heuristic

### DIFF
--- a/floss/features/extract.py
+++ b/floss/features/extract.py
@@ -33,6 +33,7 @@ from floss.features.features import (
     NzxorLoop,
     TightLoop,
     BlockCount,
+    NumAPICalls,
     TightFunction,
     KindaTightLoop,
     NzxorTightLoop,
@@ -317,12 +318,94 @@ def extract_function_loop(f):
             yield Loop(comp)
 
 
+def _iter_call_targets(insn):
+    """
+    Yield target VAs for call like branches
+    """
+    try:
+        for bva, bflags in insn.getBranches():
+            if bva is None:
+                continue
+            # envi.BR_PROC = call-like branch
+            if bflags & envi.BR_PROC:
+                yield bva
+    except Exception:
+        return
+
+
+def _looks_like_import_name(name) -> bool:
+    """
+    imported APIs usually contain a module or DLL name
+    (ex 'kernel32.CreateFileW', 'KERNEL32.dll_CreateFileW')
+    """
+    if not name:
+        return False
+    n = name.lower()
+    return "." in name or "dll" in n  # kernel32.CreateFileW style  # KERNEL32.dll_CreateFileW style
+
+
+def _is_external_api_target(vw, target_va) -> bool:
+    """
+    Decide whether a resolved call target VA is an external/API target
+    """
+    # name-based heuristic
+    try:
+        name = vw.getName(target_va)
+        if _looks_like_import_name(name):
+            return True
+    except Exception:
+        pass
+
+    # location-based heuristic
+    try:
+        loc = vw.getLocation(target_va)
+        if not loc:
+            return False
+
+        _lva, _lsize, ltype, _linfo = loc
+        # if stringified ltype mentions import, count it
+        if "import" in str(ltype).lower():
+            return True
+    except Exception:
+        pass
+
+    return False
+
+
+def extract_num_api_calls(f):
+    """
+    Count API/external calls within a function
+
+    String decoding functions usually perform arithmetic on buffers and
+    make few or no API calls. A high count suggests normal program logic
+    """
+    vw = f.vw
+    if vw is None:
+        yield NumAPICalls(0)
+        return
+
+    api_calls = 0
+
+    for bb in f.basic_blocks:
+        for insn in bb.instructions:
+            # only proceed on call mnemonics when available
+            mnem = insn.mnem.lower()
+            if mnem and mnem != "call":
+                continue
+
+            for target_va in _iter_call_targets(insn):
+                if _is_external_api_target(vw, target_va):
+                    api_calls += 1
+
+    yield NumAPICalls(api_calls)
+
+
 FUNCTION_HANDLERS = (
     extract_function_calls_to,
     extract_function_loop,
     extract_function_kinda_tight_loop,
     # extract_function_order,  # TODO decoding functions are often one of the first in a program
-    # extract_num_api_calls,  # TODO decoding functions don't normally contain many (API) calls
+    extract_num_api_calls,
 )
 
 

--- a/floss/features/features.py
+++ b/floss/features/features.py
@@ -199,3 +199,32 @@ class NzxorLoop(Feature):
 
     def score(self):
         return 1.0
+
+
+class NumAPICalls(Feature):
+    """
+    Number of external/API calls made by a function.
+
+    Heuristic motivation:
+      decoding/deobfuscation functions often do tight arithmetic over buffers
+      and tend to have few or zero API calls
+    """
+
+    weight = LOW
+
+    def __init__(self, api_call_count: int):
+        super(NumAPICalls, self).__init__(int(api_call_count))
+
+    def score(self):
+        # 0-1 API calls: very decoder-like
+        # 2-4: plausible
+        # 5-8: less likely
+        # >8: unlikely
+        if self.value <= 1:
+            return 1.0
+        elif 2 <= self.value <= 4:
+            return 0.7
+        elif 5 <= self.value <= 8:
+            return 0.3
+        else:
+            return 0.1


### PR DESCRIPTION
In reference to the discussion here #1212 

### What it is?
`extract_num_api_calls` is  a function-level heuristic that counts how many API calls a function makes
- Decoding/decryption routines usually do a lot of tight arithmetic / bitwise operations over buffers(like xor)
- They often operate mostly on memory and registers and may call very few external/library APIs (sometimes none)
- In contrast, “normal” higher level functions (UI, file I/O, networking) often make many API/library calls

Low API call count : more consistent with a decoding rpoutine
High API call count : less consistent with decoding 

### How is it implemented ?
- count call instructions where vivisect resolved the target AND the target is not within the current function and not within the same binary’s code (it’s an import / external)
- also count calls “to” imported symbols by checking for a name like kernel32.CreateFileW or similar

### Test results
With the heuristic in place the score has improved(same num of strings found)
Tests were executed on `tests/data/malware/stackstrings/a294620543334a721a2ae8eaaf9680a0786f4b9a216d75b55cfd28f39e9430ea.exe_`

- Without this heuristic:
```
"functions": {
            "analyzed_decoded_strings": 10,
            "analyzed_stack_strings": 8,
            "analyzed_tight_strings": 2,
            "decoding_function_scores": {
                "4198400": {
                    "score": 0.543,
                    "xrefs_to": 0
                },
                "4198864": {
                    "score": 0.554,
                    "xrefs_to": 1
                },
                "4199600": {
                    "score": 0.764,
                    "xrefs_to": 1
                },
                "4199696": {
                    "score": 0.456,
                    "xrefs_to": 1
                },
                "4199728": {
                    "score": 0.95,
                    "xrefs_to": 25
                },
                "4200272": {
                    "score": 0.472,
                    "xrefs_to": 2
                },
                "4200976": {
                    "score": 0.472,
                    "xrefs_to": 2
                },
                "4203168": {
                    "score": 0.634,
                    "xrefs_to": 3
                },
                "4205184": {
                    "score": 0.751,
                    "xrefs_to": 6
                },
                "4205328": {
                    "score": 0.804,
                    "xrefs_to": 3
                }
            }

"runtime": {
            "decoded_strings": 3.8492,
            "find_features": 0.1299,
            "language_strings": 0,
            "stack_strings": 0.2986,
            "start_date": "2026-02-13T13:20:57.460886Z",
            "static_strings": 0.0004,
            "tight_strings": 0.2559,
            "total": 7.9169,
            "vivisect": 3.3805
        }
```

With this heuristic :
```
"functions": {
            "analyzed_decoded_strings": 10,
            "analyzed_stack_strings": 8,
            "analyzed_tight_strings": 2,
            "decoding_function_scores": {
                "4198400": {
                    "score": 0.6,
                    "xrefs_to": 0
                },
                "4198864": {
                    "score": 0.61,
                    "xrefs_to": 1
                },
                "4199600": {
                    "score": 0.788,
                    "xrefs_to": 1
                },
                "4199696": {
                    "score": 0.547,
                    "xrefs_to": 1
                },
                "4199728": {
                    "score": 0.953,
                    "xrefs_to": 25
                },
                "4200272": {
                    "score": 0.56,
                    "xrefs_to": 2
                },
                "4200976": {
                    "score": 0.56,
                    "xrefs_to": 2
                },
                "4203168": {
                    "score": 0.68,
                    "xrefs_to": 3
                },
                "4205184": {
                    "score": 0.762,
                    "xrefs_to": 6
                },
                "4205328": {
                    "score": 0.822,
                    "xrefs_to": 3
                }
            },
            "discovered": 10,
            "library": 0
        }
    }

"runtime": {
            "decoded_strings": 3.9446,
            "find_features": 0.0661,
            "language_strings": 0,
            "stack_strings": 0.3221,
            "start_date": "2026-02-13T13:36:02.831242Z",
            "static_strings": 0.0004,
            "tight_strings": 0.3008,
            "total": 8.1679,
            "vivisect": 3.5308
        }
```

@mr-tz  Looking forward to your insights !