### PR TITLE
Fix RICH_HEADER attribute error

### DIFF
--- a/floss/qs/main.py
+++ b/floss/qs/main.py
@@ -890,7 +890,7 @@ def collect_pe_structures(slice: Slice, pe: pefile.PE) -> Sequence[Structure]:
                         )
                     )
 
-    if hasattr(pe, 'RICH_HEADER'):
+    if hasattr(pe, 'RICH_HEADER') and pe.RICH_HEADER:
         key_bytes = pe.RICH_HEADER.key
 
         rich_sig_offset = pe.__data__.find(b'Rich', 0x40, pe.DOS_HEADER.e_lfanew)


### PR DESCRIPTION
@williballenthin @mr-tz sorry for not catching this earlier, but there was a bug in #1231 which expected a RICH_HEADER.key if the attribute was already existing but `None`.

While running qs against the test binaries just now, in `dotnet-hello.exe` it resulted in an AttributeError.

This is fixed here by adding an additional check to ensure the rich header object isn't `None` to ensure it doesn't throw an error but ignore the code and continue.


<img width="999" height="203" alt="image" src="https://github.com/user-attachments/assets/8894ad9d-f20c-4a05-a0ae-e865e4bf680c" />

This is probably a sign for me to work on better tests for qs that cover the wider range of properties being processed now 😅
