### PR TITLE
- pyinstaller include path fix

### DIFF
--- a/.github/pyinstaller/floss.spec
+++ b/.github/pyinstaller/floss.spec
@@ -33,12 +33,14 @@ with open("./floss/version.py", "wb") as f:
     )
     f.write(("__version__ = '%s'" % version).encode("utf-8"))
 
+spec_dir = os.path.dirname(os.path.abspath(SPEC))
+repo_root = os.path.abspath(os.path.join(spec_dir, "../../"))
 a = Analysis(
     # when invoking pyinstaller from the project root,
     # this gets invoked from the directory of the spec file,
     # i.e. ./.github/pyinstaller
     ["../../floss/main.py"],
-    pathex=["floss"],
+    pathex=[repo_root],
     binaries=[],
     datas=[
         # when invoking pyinstaller from the project root,

--- a/.github/pyinstaller/floss.spec
+++ b/.github/pyinstaller/floss.spec
@@ -33,8 +33,7 @@ with open("./floss/version.py", "wb") as f:
     )
     f.write(("__version__ = '%s'" % version).encode("utf-8"))
 
-spec_dir = os.path.dirname(os.path.abspath(SPEC))
-repo_root = os.path.abspath(os.path.join(spec_dir, "../../"))
+repo_root = os.path.abspath(os.path.join(os.path.dirname(SPEC), "..", ".."))
 a = Analysis(
     # when invoking pyinstaller from the project root,
     # this gets invoked from the directory of the spec file,


### PR DESCRIPTION
pyinstaller failed to create a self contained binary file on build. fixed by setting the base dir, and spec dir to run from build process from base dir.