### PR TITLE
build(deps): comment out pydantic-core to fix update conflicts

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,10 +11,6 @@ updates:
           - "pyasn1"
           - "pyasn1-modules"
           - "msgpack"
-      pydantic:
-        patterns:
-          - "pydantic"
-          - "pydantic-core"
     ignore:
       - dependency-name: "*"
         update-types: ["version-update:semver-patch"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -34,7 +34,10 @@ pyasn1-modules==0.4.2
 pycodestyle==2.14.0
 pycparser==2.23
 pydantic==2.10.1
-pydantic-core==2.27.1
+# pydantic pins pydantic-core, 
+# but dependabot updates these separately (which is broken) and is annoying,
+# so we rely on pydantic to pull in the right version of pydantic-core.
+# pydantic-core==2.27.1
 pygments==2.20.0
 pytest==8.4.1
 pytest-cov==6.2.1


### PR DESCRIPTION
Revert explicit `pydantic-core` listing and grouping to avoid version mismatch conflicts during updates.

As discussed, `pydantic` and `pydantic-core` are tightly coupled, and keeping them as separate explicit dependencies in `requirements.txt` leads to broken PRs when Dependabot tries to update them to incompatible versions.

### Changes:
- Commented out `pydantic-core` in `requirements.txt`.
- Removed the `pydantic` group from `.github/dependabot.yml`.