### PR TITLE
Get list of bb start/end eas for loops in `extract.py`

### DIFF
--- a/floss/features/extract.py
+++ b/floss/features/extract.py
@@ -291,6 +291,7 @@ def extract_function_loop(f):
     parse if a function has a loop
     """
     edges = []
+    bb_by_va = {bb.va: bb for bb in f.basic_blocks}
 
     for bb in f.basic_blocks:
         if len(bb.instructions) > 0:
@@ -313,8 +314,15 @@ def extract_function_loop(f):
     comps = strongly_connected_components(g)
     for comp in comps:
         if len(comp) >= 2:
-            # TODO get list of bb start/end eas
-            yield Loop(comp)
+            loop_bb_ranges = []
+            for bb_va in sorted(comp):
+                bb = bb_by_va.get(bb_va)
+                if bb is None:
+                    continue
+
+                loop_bb_ranges.append((bb.va, bb.va + bb.size))
+
+            yield Loop(comp, bb_ranges=loop_bb_ranges)
 
 
 FUNCTION_HANDLERS = (

--- a/floss/features/features.py
+++ b/floss/features/features.py
@@ -172,10 +172,11 @@ class CallsTo(Feature):
 class Loop(Feature):
     weight = MEDIUM
 
-    def __init__(self, comp):
+    def __init__(self, comp, bb_ranges=None):
         super(Loop, self).__init__(len(comp))
 
         self.comp = comp
+        self.bb_ranges = bb_ranges or []
 
     def score(self):
         return 1.0

--- a/floss/main.py
+++ b/floss/main.py
@@ -126,7 +126,8 @@ def make_parser(argv):
         " 1. Go:   strings from binaries written in Go\n"
         " 2. Rust: strings from binaries written in Rust\n"
     )
-    epilog = textwrap.dedent("""
+    epilog = textwrap.dedent(
+        """
         only displaying core arguments, run `floss -H` to see all supported options
 
         examples:
@@ -138,8 +139,10 @@ def make_parser(argv):
 
           only extract stack and tight strings
             floss --only stack tight -- suspicious.exe
-        """)
-    epilog_advanced = textwrap.dedent("""
+        """
+    )
+    epilog_advanced = textwrap.dedent(
+        """
         examples:
           extract all strings from 32-bit shellcode
             floss -f sc32 shellcode.bin
@@ -149,7 +152,8 @@ def make_parser(argv):
         
           extract strings from a binary written in Go (if automatic language identification fails)
             floss --language go program.exe
-        """)
+        """
+    )
 
     show_all_options = "-H" in argv
 

--- a/tests/test_load.py
+++ b/tests/test_load.py
@@ -3,7 +3,8 @@ import textwrap
 import floss.main
 
 # floss --no static -j tests/data/src/decode-in-place/bin/test-decode-in-place.exe
-RESULTS = textwrap.dedent("""
+RESULTS = textwrap.dedent(
+    """
 {
     "analysis": {
         "enable_decoded_strings": true,
@@ -83,7 +84,8 @@ RESULTS = textwrap.dedent("""
         "tight_strings": []
     }
 }
-""")
+"""
+)
 
 
 def test_load(tmp_path):


### PR DESCRIPTION
In reference to the TODO in `extract.py`:
```python
        if len(comp) >= 2:
            # TODO get list of bb start/end eas
            yield Loop(comp)
 ```

- Added loop BB range extraction for each SCC loop `(len(comp) >= 2)`, it now builds sorted `(start_ea, end_ea)` pairs from function basic blocks and passes them to Loop.
- Extended `Loop` in `features.py` to keep `bb_ranges` while preserving existing comp behavior for compatibility

PS. `main.py` and `tests/test_load.py` got added due to black formatting, they have nothing to do with this PR