### PR TITLE
build(deps): fix mypy 1.20.0 failures

### DIFF
--- a/floss/identify.py
+++ b/floss/identify.py
@@ -31,7 +31,14 @@ from floss.features.extract import (
     extract_function_features,
     extract_basic_block_features,
 )
-from floss.features.features import Arguments, BlockCount, TightFunction, InstructionCount
+from floss.features.features import (
+    Arguments,
+    TightLoop,
+    BlockCount,
+    TightFunction,
+    KindaTightLoop,
+    InstructionCount,
+)
 
 logger = floss.logging_.getLogger(__name__)
 
@@ -103,9 +110,7 @@ def get_function_fvas(functions) -> List[int]:
 
 
 def get_functions_with_tightloops(functions):
-    return get_functions_with_features(
-        functions, (floss.features.features.TightLoop, floss.features.features.KindaTightLoop)
-    )
+    return get_functions_with_features(functions, (TightLoop, KindaTightLoop))
 
 
 def get_functions_without_tightloops(functions):

--- a/floss/utils.py
+++ b/floss/utils.py
@@ -607,13 +607,12 @@ def get_static_strings(sample: Path, min_length: int) -> list:
         logger.warning("File is empty")
         return []
 
-    with sample.open("r") as f:
+    with sample.open("rb") as f:
         if hasattr(mmap, "MAP_PRIVATE"):
             # unix
-            kwargs = {"flags": mmap.MAP_PRIVATE, "prot": mmap.PROT_READ}
+            with mmap.mmap(f.fileno(), 0, flags=mmap.MAP_PRIVATE, prot=mmap.PROT_READ) as buf:
+                return list(extract_ascii_unicode_strings(buf, min_length))
         else:
             # windows
-            kwargs = {"access": mmap.ACCESS_READ}
-
-        with contextlib.closing(mmap.mmap(f.fileno(), 0, **kwargs)) as buf:
-            return list(extract_ascii_unicode_strings(buf, min_length))
+            with mmap.mmap(f.fileno(), 0, access=mmap.ACCESS_READ) as buf:
+                return list(extract_ascii_unicode_strings(buf, min_length))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -128,7 +128,7 @@ dev = [
     "pycodestyle==2.14.0",
     "black==26.3.1",
     "isort==8.0.1",
-    "mypy==1.18.2",
+    "mypy==1.20.0",
     # type stubs for mypy
     "types-PyYAML==6.0.10",
     "types-tabulate==0.9.0.20240106",

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,7 +19,7 @@ log-symbols==0.0.14
 markdown-it-py==4.0.0
 mdurl==0.1.2
 msgpack==1.1.2
-mypy==1.18.2
+mypy==1.20.0
 networkx==3.4.2
 nodeenv==1.10.0
 packaging==25.0


### PR DESCRIPTION
This PR fixes type errors introduced by the mypy 1.20.0 update.

### Changes:
1. **floss/utils.py**: Made the  call explicit to avoid an incompatible argument type error ( vs ).
2. **floss/identify.py**: Properly imported and used  and  features to resolve a module attribute error.
3. **requirements.txt** & **pyproject.toml**: Updated  to 1.20.0 to match the intended dependency update.

Verified with  and .