### PR TITLE
scripts: add project root to sys.path

### DIFF
--- a/scripts/idaplugin.py
+++ b/scripts/idaplugin.py
@@ -23,10 +23,15 @@ email: willi.ballenthin@gmail.com
 """
 
 import os
+import sys
 import time
 import logging
 from typing import List, Union
 from pathlib import Path
+
+# add the project root to the path so we can find the floss module
+# regardless of how this script is invoked.
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
 import idc
 import viv_utils

--- a/scripts/render-binja-import-script.py
+++ b/scripts/render-binja-import-script.py
@@ -26,11 +26,16 @@ Usage:
   # now run `apply_floss.py` in Binary Ninja
 """
 
+import os
 import sys
 import base64
 import logging
 import argparse
 from pathlib import Path
+
+# add the project root to the path so we can find the floss module
+# regardless of how this script is invoked.
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
 from floss.results import AddressType, ResultDocument
 

--- a/scripts/render-ghidra-import-script.py
+++ b/scripts/render-ghidra-import-script.py
@@ -31,11 +31,16 @@ Usage:
   # now run `apply_floss.py` in Ghidra Script Manager
 """
 
+import os
 import sys
 import base64
 import logging
 import argparse
 from pathlib import Path
+
+# add the project root to the path so we can find the floss module
+# regardless of how this script is invoked.
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
 from floss.results import AddressType, ResultDocument
 

--- a/scripts/render-ida-import-script.py
+++ b/scripts/render-ida-import-script.py
@@ -34,11 +34,16 @@ Usage:
   # now run `apply_floss.py` in IDA
 """
 
+import os
 import sys
 import base64
 import logging
 import argparse
 from pathlib import Path
+
+# add the project root to the path so we can find the floss module
+# regardless of how this script is invoked.
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
 from floss.results import AddressType, ResultDocument
 

--- a/scripts/render-r2-import-script.py
+++ b/scripts/render-r2-import-script.py
@@ -27,11 +27,16 @@ Usage:
   # now run `apply_floss.py` in radare2
 """
 
+import os
 import sys
 import base64
 import logging
 import argparse
 from pathlib import Path
+
+# add the project root to the path so we can find the floss module
+# regardless of how this script is invoked.
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
 from floss.results import AddressType, ResultDocument
 

--- a/scripts/render-x64dbg-database.py
+++ b/scripts/render-x64dbg-database.py
@@ -26,6 +26,7 @@ Usage:
   # open `database.json` in x64dbg
 """
 
+import os
 import sys
 import json
 import logging
@@ -34,6 +35,10 @@ import dataclasses
 from typing import Dict, List
 from pathlib import Path
 from dataclasses import field
+
+# add the project root to the path so we can find the floss module
+# regardless of how this script is invoked.
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
 from pydantic.dataclasses import dataclass
 


### PR DESCRIPTION
Fixes #1185.

This PR adds the project root to `sys.path` in various helper scripts. This ensures they can find the `floss` module regardless of how they are invoked (e.g. from within the `scripts/` directory) or if `floss` is not installed in the current environment.