### PR TITLE
ci: fix broken GitHub Action hashes in web-release workflow

### DIFF
--- a/.github/workflows/web-release.yml
+++ b/.github/workflows/web-release.yml
@@ -17,10 +17,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Set up Node.js
-        uses: actions/setup-node@1d1121622333fef74a132203b0c2602c71a60393 # v4.2.2
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 24
           cache: 'npm'
@@ -35,7 +35,7 @@ jobs:
         working-directory: ./qs-viewer
 
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dee46217119b # v3.0.1
+        uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0
         with:
           # vite-plugin-singlefile puts everything into index.html in the dist folder
           path: ./qs-viewer/dist


### PR DESCRIPTION
This PR fixes the broken GitHub Action hashes for `actions/setup-node` and `actions/upload-pages-artifact` in the `web-release` workflow. The previous hashes were incorrect and prevented the CI from running.