### PR TITLE
perf: optimize is_all_zeros using fast bytes comparison

### DIFF
--- a/floss/utils.py
+++ b/floss/utils.py
@@ -392,7 +392,8 @@ def get_runtime_diff(time0):
 
 
 def is_all_zeros(buffer: bytes):
-    return all([b == 0 for b in buffer])
+    buffer = bytes(buffer)
+    return buffer == b"\x00" * len(buffer)
 
 
 def get_progress_bar(functions, disable_progress, desc="", unit=""):

--- a/floss/utils.py
+++ b/floss/utils.py
@@ -392,8 +392,11 @@ def get_runtime_diff(time0):
 
 
 def is_all_zeros(buffer: bytes):
-    buffer = bytes(buffer)
-    return buffer == b"\x00" * len(buffer)
+    if not buffer:
+        return True
+    if buffer[0] != 0:
+        return False
+    return buffer == bytes(len(buffer))
 
 
 def get_progress_bar(functions, disable_progress, desc="", unit=""):


### PR DESCRIPTION
Replaces `all([b == 0 for b in buffer])` in is_all_zeros with `buffer == b"\x00" * len(buffer)`. This eliminates intermediate list allocations and leverages C-level byte string equality checking for performance. Similar optimizations were validated and incorporated upstream in capa (PR 3078).