### PR TITLE
ci: add pinact workflow to verify pin hashes and versions

### DIFF
--- a/.github/workflows/verify-pins.yml
+++ b/.github/workflows/verify-pins.yml
@@ -1,4 +1,4 @@
-name: Verify Action Pins
+name: Verify GitHub Action Pins
 
 on:
   pull_request:

--- a/.github/workflows/verify-pins.yml
+++ b/.github/workflows/verify-pins.yml
@@ -15,6 +15,6 @@ jobs:
       - uses: suzuki-shunsuke/pinact-action@896d595f299e71d65b9d28349d6956abe144390a # v3.0.0
         with:
           verify: "true"
-          fix: "false"
+          fix: "true"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/verify-pins.yml
+++ b/.github/workflows/verify-pins.yml
@@ -1,0 +1,20 @@
+name: Verify Action Pins
+
+on:
+  pull_request:
+    paths:
+      - ".github/workflows/**"
+
+jobs:
+  verify:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+      - uses: suzuki-shunsuke/pinact-action@896d595f299e71d65b9d28349d6956abe144390a # v3.0.0
+        with:
+          verify: "true"
+          fix: "false"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
closes #1280 

The options I went through and finalized with reason @mr-tz 

- zizmor is overkill honestly, too many knobs we don't need just for a sha verifier
- pinact works and has a github action already, the `-verify` flag does exactly what the requirements demand.
- custom script is not needed and adds more tech debt

Bad action test: https://github.com/vee1e/flare-floss/pull/2

<img width="1089" height="691" alt="image" src="https://github.com/user-attachments/assets/a7230d00-3122-449c-a464-1f816f22390d" />

Good action test: https://github.com/vee1e/flare-floss/pull/3

<img width="1074" height="831" alt="image" src="https://github.com/user-attachments/assets/7429c97a-498b-4a5d-96ef-548dfd784f3e" />


Do let me know if the approach is correct or not and what to change