### PR TITLE
feat: add QS ELF parser prototype

### DIFF
--- a/floss/qs/main.py
+++ b/floss/qs/main.py
@@ -27,8 +27,9 @@ from rich.text import Text
 from rich.style import Style
 from rich.console import Console
 from elftools.elf.elffile import ELFFile
-from elftools.elf.relocation import RelocationSection
 from elftools.elf.constants import SH_FLAGS
+from elftools.elf.relocation import RelocationSection
+from elftools.common.exceptions import ELFError
 
 import floss.main
 import floss.qs.db.gp
@@ -108,8 +109,8 @@ class Slice(BaseModel):
 
     def contains_range(self, offset: int, size: int) -> bool:
         """
-        checks if this slice's buffer contains the given range,
-        where offset is relative to the start of this slice's buffer.
+        checks if this slice contains the given range,
+        where offset is relative to the start of this slice.
         """
         if not (0 <= offset <= self.range.length):
             return False
@@ -608,7 +609,7 @@ def get_reloc_offsets(slice: Slice, pe: pefile.PE) -> Set[int]:
     return ret
 
 
-def get_relocations_elf(slice: Slice, elf: ELFFile) -> List[Tuple[int, int]]:
+def get_relocations_elf(slice_: Slice, elf: ELFFile) -> List[Tuple[int, int]]:
     ranges: List[Tuple[int, int]] = []
 
     for section in elf.iter_sections():
@@ -616,11 +617,11 @@ def get_relocations_elf(slice: Slice, elf: ELFFile) -> List[Tuple[int, int]]:
             offset = section["sh_offset"]
             size = section["sh_size"]
 
-            if not slice.contains_range(offset, size):
+            if not slice_.contains_range(offset, size):
                 logger.warning("relocation directory points to an invalid location, skipping")
                 continue
 
-            ranges.append((slice.offset + offset, slice.offset + offset + size - 1))
+            ranges.append((slice_.offset + offset, slice_.offset + offset + size - 1))
     return _merge_overlapping_ranges(ranges)
 
 
@@ -813,13 +814,13 @@ class Structure(BaseModel):
     name: str
 
 
-def collect_elf_structures(slice: Slice, elf: ELFFile) -> Sequence[Structure]:
+def collect_elf_structures(slice_: Slice, elf: ELFFile) -> Sequence[Structure]:
     structures: List[Structure] = []
 
     # ELF file header: 52 bytes (32-bit) or 64 bytes (64-bit)
     header_size = 52 if elf.elfclass == 32 else 64
-    if slice.contains_range(0, header_size):
-        structures.append(Structure(slice=slice.slice(0, header_size), name="elf header"))
+    if slice_.contains_range(0, header_size):
+        structures.append(Structure(slice=slice_.slice(0, header_size), name="elf header"))
 
     # Program header table
     phoff = elf.header["e_phoff"]
@@ -827,8 +828,8 @@ def collect_elf_structures(slice: Slice, elf: ELFFile) -> Sequence[Structure]:
     phnum = elf.header["e_phnum"]
     if phnum > 0 and phentsize > 0:
         ph_total = phentsize * phnum
-        if slice.contains_range(phoff, ph_total):
-            structures.append(Structure(slice=slice.slice(phoff, ph_total), name="program header"))
+        if slice_.contains_range(phoff, ph_total):
+            structures.append(Structure(slice=slice_.slice(phoff, ph_total), name="program header"))
 
     # Section header table
     shoff = elf.header["e_shoff"]
@@ -836,8 +837,8 @@ def collect_elf_structures(slice: Slice, elf: ELFFile) -> Sequence[Structure]:
     shnum = elf.header["e_shnum"]
     if shnum > 0 and shentsize > 0:
         sh_total = shentsize * shnum
-        if slice.contains_range(shoff, sh_total):
-            structures.append(Structure(slice=slice.slice(shoff, sh_total), name="section header"))
+        if slice_.contains_range(shoff, sh_total):
+            structures.append(Structure(slice=slice_.slice(shoff, sh_total), name="section header"))
 
     # String tables (.shstrtab, .strtab, .dynstr) and symbol tables (.symtab, .dynsym)
     for section in elf.iter_sections():
@@ -849,13 +850,13 @@ def collect_elf_structures(slice: Slice, elf: ELFFile) -> Sequence[Structure]:
         offset = section["sh_offset"]
         size = section["sh_size"]
 
-        if not slice.contains_range(offset, size):
+        if not slice_.contains_range(offset, size):
             continue
 
         if section["sh_type"] == "SHT_STRTAB":
-            structures.append(Structure(slice=slice.slice(offset, size), name="string table"))
+            structures.append(Structure(slice=slice_.slice(offset, size), name="string table"))
         elif section["sh_type"] in {"SHT_SYMTAB", "SHT_DYNSYM"}:
-            structures.append(Structure(slice=slice.slice(offset, size), name="symbol table"))
+            structures.append(Structure(slice=slice_.slice(offset, size), name="symbol table"))
 
     return structures
 
@@ -1249,13 +1250,13 @@ class MachOFatLayout(Layout):
     pass
 
 
-def compute_elf_layout(slice: Slice, xor_key: int | None) -> Layout:
-    data = slice.data
+def compute_elf_layout(slice_: Slice, xor_key: int | None) -> Layout:
+    data = slice_.data
 
     elf = ELFFile(io.BytesIO(data))
 
-    structures = collect_elf_structures(slice, elf)
-    relocation_offsets = OffsetRanges.from_merged_ranges(get_relocations_elf(slice, elf))
+    structures = collect_elf_structures(slice_, elf)
+    relocation_offsets = OffsetRanges.from_merged_ranges(get_relocations_elf(slice_, elf))
 
     structures_by_address: Dict[int, Structure] = {}
     for structure in structures:
@@ -1278,19 +1279,19 @@ def compute_elf_layout(slice: Slice, xor_key: int | None) -> Layout:
             size = section["sh_size"]
             is_exec = bool(section["sh_flags"] & SH_FLAGS.SHF_EXECINSTR)
 
-            if offset >= slice.range.length:
+            if offset >= slice_.range.length:
                 logger.warning("section %s out of range", name)
                 continue
 
-            if offset + size > slice.range.length:
+            if offset + size > slice_.range.length:
                 size_orig = size
-                size = slice.range.length - offset
+                size = slice_.range.length - offset
                 logger.warning(
                     "section size %s out of range, truncating from 0x%x to 0x%x bytes", name, size_orig, size
                 )
 
             file_sections.append((offset, size, name, is_exec))
-    except Exception as e:
+    except ELFError as e:
         logger.warning("failed to parse ELF sections: %s", e)
 
     # Build code_offsets from executable sections before constructing the layout.
@@ -1301,7 +1302,7 @@ def compute_elf_layout(slice: Slice, xor_key: int | None) -> Layout:
     code_offsets = OffsetRanges.from_merged_ranges(_merge_overlapping_ranges(exec_ranges))
 
     layout = ELFLayout(
-        slice=slice,
+        slice=slice_,
         name="elf",
         xor_key=xor_key,
         relocation_offsets=relocation_offsets,
@@ -1318,7 +1319,7 @@ def compute_elf_layout(slice: Slice, xor_key: int | None) -> Layout:
         if offset < cursor:
             logger.debug("section %s overlaps previous section, skipping", name)
             continue
-        layout.add_child(SectionLayout(slice=slice.slice(offset, size), name=name))
+        layout.add_child(SectionLayout(slice=slice_.slice(offset, size), name=name))
         cursor = offset + size
 
     return layout
@@ -2052,7 +2053,7 @@ def compute_layout(slice: Slice) -> Layout:
     elif decoded_slice.data.startswith(b"\x7fELF"):
         try:
             return compute_elf_layout(decoded_slice, xor_key)
-        except Exception as e:
+        except ELFError as e:
             logger.debug("failed to parse as ELF file: %s", e)
     else:
         logger.debug("unrecognized file format, falling back to binary layout")

--- a/floss/qs/main.py
+++ b/floss/qs/main.py
@@ -2013,21 +2013,19 @@ def compute_layout(slice: Slice) -> Layout:
             return compute_pe_layout(decoded_slice, xor_key)
         except ValueError as e:
             logger.debug("failed to parse as PE file: %s", e)
-            # Fall back to using the default binary layout
-            pass
-
-    if _is_macho_magic(_get_u32_be(slice.data, 0)):
+    elif _is_macho_magic(_get_u32_be(slice.data, 0)):
         try:
             return compute_macho_layout(slice)
         except Exception as e:
             # TODO: narrow exception handling once machofile error types are clearer.
             logger.debug("failed to parse as Mach-O file: %s", e)
-
-    if decoded_slice.data.startswith(b"\x7fELF"):
+    elif decoded_slice.data.startswith(b"\x7fELF"):
         try:
             return compute_elf_layout(decoded_slice, xor_key)
         except Exception as e:
             logger.debug("failed to parse as ELF file: %s", e)
+    else:
+        logger.debug("unrecognized file format, falling back to binary layout")
 
     return SegmentLayout(
         slice=slice,

--- a/floss/qs/main.py
+++ b/floss/qs/main.py
@@ -815,14 +815,46 @@ class Structure(BaseModel):
 def collect_elf_structures(slice: Slice, elf: ELFFile) -> Sequence[Structure]:
     structures: List[Structure] = []
 
-    shstrtab = elf.get_section_by_name(".shstrtab")
-    if shstrtab and slice.contains_range(shstrtab["sh_offset"], shstrtab["sh_size"]):
-        structures.append(
-            Structure(
-                slice=slice.slice(shstrtab["sh_offset"], shstrtab["sh_size"]),
-                name="section header",
-            )
-        )
+    # ELF file header: 52 bytes (32-bit) or 64 bytes (64-bit)
+    header_size = 52 if elf.elfclass == 32 else 64
+    if slice.contains_range(0, header_size):
+        structures.append(Structure(slice=slice.slice(0, header_size), name="elf header"))
+
+    # Program header table
+    phoff = elf.header["e_phoff"]
+    phentsize = elf.header["e_phentsize"]
+    phnum = elf.header["e_phnum"]
+    if phnum > 0 and phentsize > 0:
+        ph_total = phentsize * phnum
+        if slice.contains_range(phoff, ph_total):
+            structures.append(Structure(slice=slice.slice(phoff, ph_total), name="program header"))
+
+    # Section header table
+    shoff = elf.header["e_shoff"]
+    shentsize = elf.header["e_shentsize"]
+    shnum = elf.header["e_shnum"]
+    if shnum > 0 and shentsize > 0:
+        sh_total = shentsize * shnum
+        if slice.contains_range(shoff, sh_total):
+            structures.append(Structure(slice=slice.slice(shoff, sh_total), name="section header"))
+
+    # String tables (.shstrtab, .strtab, .dynstr) and symbol tables (.symtab, .dynsym)
+    for section in elf.iter_sections():
+        if section["sh_size"] == 0:
+            continue
+        if section["sh_type"] == "SHT_NOBITS":
+            continue
+
+        offset = section["sh_offset"]
+        size = section["sh_size"]
+
+        if not slice.contains_range(offset, size):
+            continue
+
+        if section["sh_type"] == "SHT_STRTAB":
+            structures.append(Structure(slice=slice.slice(offset, size), name="string table"))
+        elif section["sh_type"] in {"SHT_SYMTAB", "SHT_DYNSYM"}:
+            structures.append(Structure(slice=slice.slice(offset, size), name="symbol table"))
 
     return structures
 
@@ -940,24 +972,19 @@ def collect_pe_structures(slice: Slice, pe: pefile.PE) -> Sequence[Structure]:
                         )
                     )
 
-    if hasattr(pe, 'RICH_HEADER') and pe.RICH_HEADER:
+    if hasattr(pe, "RICH_HEADER") and pe.RICH_HEADER:
         key_bytes = pe.RICH_HEADER.key
 
-        rich_sig_offset = pe.__data__.find(b'Rich', 0x40, pe.DOS_HEADER.e_lfanew)
+        rich_sig_offset = pe.__data__.find(b"Rich", 0x40, pe.DOS_HEADER.e_lfanew)
         # The structure end is 'Rich' (4) + key (4) = 8 bytes
         rich_end = rich_sig_offset + 8
 
         # Find the start of rich header by looking for 'DanS' XORed with the key
-        xor_dans = bytes(a ^ b for a, b in zip(b'DanS', key_bytes))
+        xor_dans = bytes(a ^ b for a, b in zip(b"DanS", key_bytes))
         rich_start = pe.__data__.rfind(xor_dans, 0x40, rich_sig_offset)
 
         if rich_sig_offset != -1 and rich_start != -1:
-            structures.append(
-                Structure(
-                    slice=slice.slice(rich_start, rich_end - rich_start),
-                    name="rich header"
-                )
-            )
+            structures.append(Structure(slice=slice.slice(rich_start, rich_end - rich_start), name="rich header"))
 
     return structures
 
@@ -1620,9 +1647,7 @@ def _parse_fat_arches(data: bytes) -> List[Tuple[str, int, int]]:
         else:
             if offset + 20 > len(data):
                 break
-            cputype, cpusubtype, arch_offset, size, _align = struct.unpack(
-                endian + "IIIII", data[offset : offset + 20]
-            )
+            cputype, cpusubtype, arch_offset, size, _align = struct.unpack(endian + "IIIII", data[offset : offset + 20])
             offset += 20
 
         arch_name = _format_macho_arch(cputype, cpusubtype)
@@ -1755,9 +1780,7 @@ def _attach_nested_layout(parent: Layout, child: Layout):
         parent.add_child(child)
 
 
-def _parse_superblob_blobs(
-    slice_: Slice, cs_offset: int, cs_size: int
-) -> Sequence[Tuple[int, int, int]]:
+def _parse_superblob_blobs(slice_: Slice, cs_offset: int, cs_size: int) -> Sequence[Tuple[int, int, int]]:
     blobs: List[Tuple[int, int, int]] = []
     if cs_size <= 0:
         return blobs
@@ -2258,8 +2281,11 @@ def render_strings(
                         is_group_start = True
 
             line = render_string(
-                console.width, string, tag_rules,
-                prev_tags=prev_tags, prev_tags_width=prev_tags_width,
+                console.width,
+                string,
+                tag_rules,
+                prev_tags=prev_tags,
+                prev_tags_width=prev_tags_width,
                 is_group_end=is_group_end,
                 is_group_start=is_group_start,
             )

--- a/floss/qs/main.py
+++ b/floss/qs/main.py
@@ -1,11 +1,11 @@
 import io
-import struct
 import re
 import abc
 import sys
 import json
 import time
 import bisect
+import struct
 import hashlib
 import logging
 import pathlib
@@ -18,14 +18,16 @@ from typing import Set, Dict, List, Tuple, Literal, Callable, Iterable, Optional
 from collections import defaultdict
 
 import pefile
-import machofile
 import colorama
 import lancelot
+import machofile
 import rich.traceback
 from pydantic import Field, BaseModel, ConfigDict
 from rich.text import Text
 from rich.style import Style
 from rich.console import Console
+from elftools.elf.elffile import ELFFile
+from elftools.elf.relocation import RelocationSection
 
 import floss.main
 import floss.qs.db.gp
@@ -605,6 +607,23 @@ def get_reloc_offsets(slice: Slice, pe: pefile.PE) -> Set[int]:
     return ret
 
 
+def get_relocations_elf(slice: Slice, elf: ELFFile) -> Set[int]:
+    ret: Set[int] = set()
+
+    for section in elf.iter_sections():
+        if isinstance(section, RelocationSection):
+            offset = section["sh_offset"]
+            size = section["sh_size"]
+
+            if not slice.contains_range(offset, size):
+                logger.warning("relocation directory points to an invalid location, skipping")
+                continue
+
+            for fo in slice.range.slice(offset, size):
+                ret.add(fo)
+    return ret
+
+
 def check_is_xor(xor_key: int | None):
     if isinstance(xor_key, int):
         return ("#decoded",)
@@ -792,6 +811,21 @@ def load_databases() -> Sequence[Tagger]:
 class Structure(BaseModel):
     slice: Slice
     name: str
+
+
+def collect_elf_structures(slice: Slice, elf: ELFFile) -> Sequence[Structure]:
+    structures = []
+
+    shstrtab = elf.get_section_by_name(".shstrtab")
+    if shstrtab and slice.contains_range(shstrtab["sh_offset"], shstrtab["sh_size"]):
+        structures.append(
+            Structure(
+                slice=slice.slice(shstrtab["sh_offset"], shstrtab["sh_size"]),
+                name="section header",
+            )
+        )
+
+    return structures
 
 
 def collect_pe_structures(slice: Slice, pe: pefile.PE) -> Sequence[Structure]:
@@ -1077,7 +1111,7 @@ class Layout(BaseModel, abc.ABC):
 class SectionLayout(Layout):
     model_config = ConfigDict(arbitrary_types_allowed=True)
 
-    section: pefile.SectionStructure
+    section: Optional[pefile.SectionStructure] = None
 
 
 class SegmentLayout(Layout):
@@ -1130,6 +1164,43 @@ class PELayout(Layout):
                 child.mark_structures(structures=structures, **kwargs)
 
 
+class ELFLayout(Layout):
+    xor_key: Optional[int]
+
+    # file offsets of bytes that are part of relocation sections
+    relocation_offsets: OffsetRanges
+
+    # file offsets of bytes that are recognized as code
+    code_offsets: OffsetRanges
+
+    structures_by_address: Dict[int, Structure]
+
+    def tag_strings(self, taggers: Sequence[Tagger]):
+        def check_is_xor_tagger(s: ExtractedString) -> Sequence[Tag]:
+            return check_is_xor(self.xor_key)
+
+        def check_is_reloc_tagger(s: ExtractedString) -> Sequence[Tag]:
+            return check_is_reloc(self.relocation_offsets, s)
+
+        def check_is_code_tagger(s: ExtractedString) -> Sequence[Tag]:
+            return check_is_code(self.code_offsets, s)
+
+        taggers = tuple(taggers) + (
+            check_is_xor_tagger,
+            check_is_reloc_tagger,
+            check_is_code_tagger,
+        )
+
+        super().tag_strings(taggers)
+
+    def mark_structures(self, structures=(), **kwargs):
+        for child in self.children:
+            if isinstance(child, (SectionLayout, SegmentLayout)):
+                child.mark_structures(structures=structures + (self.structures_by_address,), **kwargs)
+            else:
+                child.mark_structures(structures=structures, **kwargs)
+
+
 class ResourceLayout(Layout):
     pass
 
@@ -1149,6 +1220,78 @@ class MachOLayout(Layout):
 
 class MachOFatLayout(Layout):
     pass
+
+
+def compute_elf_layout(slice: Slice, xor_key: int | None) -> Layout:
+    data = slice.data
+
+    elf = ELFFile(io.BytesIO(data))
+
+    structures = collect_elf_structures(slice, elf)
+    relocation_offsets = OffsetRanges.from_offsets(get_relocations_elf(slice, elf))
+
+    structures_by_address = {}
+    for structure in structures:
+        for offset in structure.slice.range:
+            structures_by_address[offset] = structure
+
+    code_offsets = OffsetRanges()
+
+    layout = ELFLayout(
+        slice=slice,
+        name="elf",
+        xor_key=xor_key,
+        relocation_offsets=relocation_offsets,
+        code_offsets=code_offsets,
+        structures_by_address=structures_by_address,
+    )
+
+    if xor_key:
+        layout.name += f" (XOR decoded with key: 0x{xor_key:x})"
+
+    # Collect valid file-backed sections, sorted by offset, deduplicating overlaps.
+    # SHT_NOBITS sections (.bss, .noptrbss) have no file content; skip them.
+    file_sections: List[Tuple[int, int, str]] = []  # (offset, size, name)
+    try:
+        for section in elf.iter_sections():
+            if section["sh_size"] == 0:
+                continue
+            if section["sh_type"] == "SHT_NOBITS":
+                continue
+
+            name = section.name
+            offset = section["sh_offset"]
+            size = section["sh_size"]
+
+            if offset >= slice.range.length:
+                logger.warning("section %s out of range", name)
+                continue
+
+            if offset + size > slice.range.length:
+                size_orig = size
+                size = slice.range.length - offset
+                logger.warning(
+                    "section size %s out of range, truncating from 0x%x to 0x%x bytes", name, size_orig, size
+                )
+
+            file_sections.append((offset, size, name))
+    except Exception as e:
+        logger.warning("failed to parse ELF sections: %s", e)
+
+    # Sort by offset, then skip any section that overlaps the previous one.
+    # cursor tracks the end of the furthest seen section (including skipped ones)
+    # so that sub-sections of a skipped wider section are also excluded.
+    file_sections.sort(key=lambda t: t[0])
+    cursor = 0
+    for offset, size, name in file_sections:
+        if offset < cursor:
+            logger.debug("section %s overlaps previous section, skipping", name)
+            cursor = max(cursor, offset + size)
+            continue
+        layout.add_child(SectionLayout(slice=slice.slice(offset, size), name=name))
+        cursor = offset + size
+
+    return layout
 
 
 def _merge_overlapping_ranges(ranges: List[Tuple[int, int]]) -> List[Tuple[int, int]]:
@@ -1178,11 +1321,12 @@ def _merge_overlapping_ranges(ranges: List[Tuple[int, int]]) -> List[Tuple[int, 
     return merged_ranges
 
 
-def _get_code_ranges(ws: lancelot.Workspace, pe: pefile.PE, slice_: Slice) -> List[Tuple[int, int]]:
+def _get_code_ranges(be2, pe: pefile.PE, slice_: Slice) -> List[Tuple[int, int]]:
     """
     Extract and return the raw, unmerged code ranges from a PE file.
     """
-    base_address = ws.base_address
+    base_address = lancelot.be2utils.find_be2_base_address(be2)
+    idx = lancelot.be2utils.BinExport2Index(be2)
 
     # cache because getting the offset is slow
     @functools.lru_cache(maxsize=None)
@@ -1194,22 +1338,29 @@ def _get_code_ranges(ws: lancelot.Workspace, pe: pefile.PE, slice_: Slice) -> Li
             return None
 
     code_ranges: List[Tuple[int, int]] = []
-    for function in ws.get_functions():
-        cfg = ws.build_cfg(function)
-        for bb in cfg.basic_blocks.values():
-            va = bb.address
-            rva = va - base_address
-            offset = get_offset_from_rva_cached(rva)
-            if offset is None:
+    for flow_graph in be2.flow_graph:
+        for basic_block_index in flow_graph.basic_block_index:
+            try:
+                basic_block = be2.basic_block[basic_block_index]
+            except IndexError:
+                logger.warning("lancelot basic block index %d out of range, skipping", basic_block_index)
                 continue
+            for _instruction_index, instruction, instruction_address in idx.basic_block_instructions(basic_block):
+                va = instruction_address
+                rva = va - base_address
+                offset = get_offset_from_rva_cached(rva)
+                if offset is None:
+                    continue
 
-            size = bb.length
+                size = len(instruction.raw_bytes)
+                if size == 0:
+                    continue
 
-            if not slice_.contains_range(offset, size):
-                logger.warning("lancelot identified code at an invalid location, skipping basic block at 0x%x", rva)
-                continue
+                if not slice_.contains_range(offset, size):
+                    logger.warning("lancelot identified code at an invalid location, skipping instruction at 0x%x", rva)
+                    continue
 
-            code_ranges.append((slice_.offset + offset, slice_.offset + offset + size - 1))
+                code_ranges.append((slice_.offset + offset, slice_.offset + offset + size - 1))
     return code_ranges
 
 
@@ -1229,19 +1380,18 @@ def compute_pe_layout(slice: Slice, xor_key: int | None) -> Layout:
         for offset in structure.slice.range:
             structures_by_address[offset] = structure
 
-    # lancelot only accepts bytes, not mmap
-    ws = None
+    be2 = None
     with timing("lancelot: load workspace"):
         try:
-            ws = lancelot.from_bytes(data)
+            be2 = lancelot.get_binexport2_from_bytes(data)
         except ValueError as e:
             logger.warning("lancelot failed to load workspace: %s", e)
 
     # contains the file offsets of bytes that are part of recognized instructions.
     code_offsets = OffsetRanges()
-    if ws:
+    if be2:
         with timing("lancelot: find code"):
-            code_ranges = _get_code_ranges(ws, pe, slice)
+            code_ranges = _get_code_ranges(be2, pe, slice)
             merged_code_ranges = _merge_overlapping_ranges(code_ranges)
             code_offsets = OffsetRanges.from_merged_ranges(merged_code_ranges)
 
@@ -1858,6 +2008,12 @@ def compute_layout(slice: Slice) -> Layout:
         except Exception as e:
             # TODO: narrow exception handling once machofile error types are clearer.
             logger.debug("failed to parse as Mach-O file: %s", e)
+
+    if decoded_slice.data.startswith(b"\x7fELF"):
+        try:
+            return compute_elf_layout(decoded_slice, xor_key)
+        except Exception as e:
+            logger.debug("failed to parse as ELF file: %s", e)
 
     return SegmentLayout(
         slice=slice,

--- a/floss/qs/main.py
+++ b/floss/qs/main.py
@@ -607,8 +607,8 @@ def get_reloc_offsets(slice: Slice, pe: pefile.PE) -> Set[int]:
     return ret
 
 
-def get_relocations_elf(slice: Slice, elf: ELFFile) -> Set[int]:
-    ret: Set[int] = set()
+def get_relocations_elf(slice: Slice, elf: ELFFile) -> List[Tuple[int, int]]:
+    ranges: List[Tuple[int, int]] = []
 
     for section in elf.iter_sections():
         if isinstance(section, RelocationSection):
@@ -619,9 +619,8 @@ def get_relocations_elf(slice: Slice, elf: ELFFile) -> Set[int]:
                 logger.warning("relocation directory points to an invalid location, skipping")
                 continue
 
-            for fo in slice.range.slice(offset, size):
-                ret.add(fo)
-    return ret
+            ranges.append((slice.offset + offset, slice.offset + offset + size - 1))
+    return _merge_overlapping_ranges(ranges)
 
 
 def check_is_xor(xor_key: int | None):
@@ -814,7 +813,7 @@ class Structure(BaseModel):
 
 
 def collect_elf_structures(slice: Slice, elf: ELFFile) -> Sequence[Structure]:
-    structures = []
+    structures: List[Structure] = []
 
     shstrtab = elf.get_section_by_name(".shstrtab")
     if shstrtab and slice.contains_range(shstrtab["sh_offset"], shstrtab["sh_size"]):
@@ -1193,10 +1192,10 @@ class ELFLayout(Layout):
 
         super().tag_strings(taggers)
 
-    def mark_structures(self, structures=(), **kwargs):
+    def mark_structures(self, structures: Optional[Tuple[Dict[int, Structure], ...]] = (), **kwargs):
         for child in self.children:
             if isinstance(child, (SectionLayout, SegmentLayout)):
-                child.mark_structures(structures=structures + (self.structures_by_address,), **kwargs)
+                child.mark_structures(structures=(structures or ()) + (self.structures_by_address,), **kwargs)
             else:
                 child.mark_structures(structures=structures, **kwargs)
 
@@ -1228,9 +1227,9 @@ def compute_elf_layout(slice: Slice, xor_key: int | None) -> Layout:
     elf = ELFFile(io.BytesIO(data))
 
     structures = collect_elf_structures(slice, elf)
-    relocation_offsets = OffsetRanges.from_offsets(get_relocations_elf(slice, elf))
+    relocation_offsets = OffsetRanges.from_merged_ranges(get_relocations_elf(slice, elf))
 
-    structures_by_address = {}
+    structures_by_address: Dict[int, Structure] = {}
     for structure in structures:
         for offset in structure.slice.range:
             structures_by_address[offset] = structure
@@ -1278,15 +1277,12 @@ def compute_elf_layout(slice: Slice, xor_key: int | None) -> Layout:
     except Exception as e:
         logger.warning("failed to parse ELF sections: %s", e)
 
-    # Sort by offset, then skip any section that overlaps the previous one.
-    # cursor tracks the end of the furthest seen section (including skipped ones)
-    # so that sub-sections of a skipped wider section are also excluded.
+    # Sort by offset, then skip any section that overlaps a previously added section.
     file_sections.sort(key=lambda t: t[0])
     cursor = 0
     for offset, size, name in file_sections:
         if offset < cursor:
             logger.debug("section %s overlaps previous section, skipping", name)
-            cursor = max(cursor, offset + size)
             continue
         layout.add_child(SectionLayout(slice=slice.slice(offset, size), name=name))
         cursor = offset + size
@@ -1321,7 +1317,7 @@ def _merge_overlapping_ranges(ranges: List[Tuple[int, int]]) -> List[Tuple[int, 
     return merged_ranges
 
 
-def _get_code_ranges(be2, pe: pefile.PE, slice_: Slice) -> List[Tuple[int, int]]:
+def _get_code_ranges(be2: "lancelot.BinExport2", pe: pefile.PE, slice_: Slice) -> List[Tuple[int, int]]:
     """
     Extract and return the raw, unmerged code ranges from a PE file.
     """
@@ -1345,11 +1341,16 @@ def _get_code_ranges(be2, pe: pefile.PE, slice_: Slice) -> List[Tuple[int, int]]
             except IndexError:
                 logger.warning("lancelot basic block index %d out of range, skipping", basic_block_index)
                 continue
+
+            current_range: Optional[Tuple[int, int]] = None
             for _instruction_index, instruction, instruction_address in idx.basic_block_instructions(basic_block):
                 va = instruction_address
                 rva = va - base_address
                 offset = get_offset_from_rva_cached(rva)
                 if offset is None:
+                    if current_range is not None:
+                        code_ranges.append(current_range)
+                        current_range = None
                     continue
 
                 size = len(instruction.raw_bytes)
@@ -1358,9 +1359,22 @@ def _get_code_ranges(be2, pe: pefile.PE, slice_: Slice) -> List[Tuple[int, int]]
 
                 if not slice_.contains_range(offset, size):
                     logger.warning("lancelot identified code at an invalid location, skipping instruction at 0x%x", rva)
+                    if current_range is not None:
+                        code_ranges.append(current_range)
+                        current_range = None
                     continue
 
-                code_ranges.append((slice_.offset + offset, slice_.offset + offset + size - 1))
+                start = slice_.offset + offset
+                end = slice_.offset + offset + size - 1
+                if current_range is None:
+                    current_range = (start, end)
+                elif start == current_range[1] + 1:
+                    current_range = (current_range[0], end)
+                else:
+                    code_ranges.append(current_range)
+                    current_range = (start, end)
+            if current_range is not None:
+                code_ranges.append(current_range)
     return code_ranges
 
 
@@ -1380,7 +1394,7 @@ def compute_pe_layout(slice: Slice, xor_key: int | None) -> Layout:
         for offset in structure.slice.range:
             structures_by_address[offset] = structure
 
-    be2 = None
+    be2: Optional[lancelot.BinExport2] = None
     with timing("lancelot: load workspace"):
         try:
             be2 = lancelot.get_binexport2_from_bytes(data)

--- a/floss/qs/main.py
+++ b/floss/qs/main.py
@@ -1285,9 +1285,7 @@ def compute_elf_layout(slice_: Slice, xor_key: int | None) -> Layout:
         if offset + size > slice_.range.length:
             size_orig = size
             size = slice_.range.length - offset
-            logger.warning(
-                "section size %s out of range, truncating from 0x%x to 0x%x bytes", name, size_orig, size
-            )
+            logger.warning("section size %s out of range, truncating from 0x%x to 0x%x bytes", name, size_orig, size)
 
         file_sections.append((offset, size, name, is_exec))
 
@@ -1349,13 +1347,16 @@ def _merge_overlapping_ranges(ranges: List[Tuple[int, int]]) -> List[Tuple[int, 
     return merged_ranges
 
 
-def _get_code_ranges(be2: "lancelot.BinExport2", pe: pefile.PE, slice_: Slice) -> List[Tuple[int, int]]:
+def _get_code_ranges(
+    be2: "lancelot.BinExport2",
+    idx: "lancelot.be2utils.BinExport2Index",
+    base_address: int,
+    pe: pefile.PE,
+    slice_: Slice,
+) -> List[Tuple[int, int]]:
     """
     Extract and return the raw, unmerged code ranges from a PE file.
     """
-    base_address = lancelot.be2utils.find_be2_base_address(be2)
-    idx = lancelot.be2utils.BinExport2Index(be2)
-
     # cache because getting the offset is slow
     @functools.lru_cache(maxsize=None)
     def get_offset_from_rva_cached(rva):
@@ -1437,7 +1438,9 @@ def compute_pe_layout(slice: Slice, xor_key: int | None) -> Layout:
     code_offsets = OffsetRanges()
     if be2:
         with timing("lancelot: find code"):
-            code_ranges = _get_code_ranges(be2, pe, slice)
+            base_address = lancelot.be2utils.find_be2_base_address(be2)
+            idx = lancelot.be2utils.BinExport2Index(be2)
+            code_ranges = _get_code_ranges(be2, idx, base_address, pe, slice)
             merged_code_ranges = _merge_overlapping_ranges(code_ranges)
             code_offsets = OffsetRanges.from_merged_ranges(merged_code_ranges)
 

--- a/floss/qs/main.py
+++ b/floss/qs/main.py
@@ -28,6 +28,7 @@ from rich.style import Style
 from rich.console import Console
 from elftools.elf.elffile import ELFFile
 from elftools.elf.relocation import RelocationSection
+from elftools.elf.constants import SH_FLAGS
 
 import floss.main
 import floss.qs.db.gp
@@ -1261,7 +1262,43 @@ def compute_elf_layout(slice: Slice, xor_key: int | None) -> Layout:
         for offset in structure.slice.range:
             structures_by_address[offset] = structure
 
-    code_offsets = OffsetRanges()
+    # Collect valid file-backed sections, sorted by offset, deduplicating overlaps.
+    # SHT_NOBITS sections (.bss, .noptrbss) have no file content; skip them.
+    # Also track executable sections (SHF_EXECINSTR) for #code tagging.
+    file_sections: List[Tuple[int, int, str, bool]] = []  # (offset, size, name, is_exec)
+    try:
+        for section in elf.iter_sections():
+            if section["sh_size"] == 0:
+                continue
+            if section["sh_type"] == "SHT_NOBITS":
+                continue
+
+            name = section.name
+            offset = section["sh_offset"]
+            size = section["sh_size"]
+            is_exec = bool(section["sh_flags"] & SH_FLAGS.SHF_EXECINSTR)
+
+            if offset >= slice.range.length:
+                logger.warning("section %s out of range", name)
+                continue
+
+            if offset + size > slice.range.length:
+                size_orig = size
+                size = slice.range.length - offset
+                logger.warning(
+                    "section size %s out of range, truncating from 0x%x to 0x%x bytes", name, size_orig, size
+                )
+
+            file_sections.append((offset, size, name, is_exec))
+    except Exception as e:
+        logger.warning("failed to parse ELF sections: %s", e)
+
+    # Build code_offsets from executable sections before constructing the layout.
+    file_sections.sort(key=lambda t: t[0])
+    exec_ranges: List[Tuple[int, int]] = [
+        (offset, offset + size) for offset, size, _name, is_exec in file_sections if is_exec
+    ]
+    code_offsets = OffsetRanges.from_merged_ranges(_merge_overlapping_ranges(exec_ranges))
 
     layout = ELFLayout(
         slice=slice,
@@ -1275,39 +1312,9 @@ def compute_elf_layout(slice: Slice, xor_key: int | None) -> Layout:
     if xor_key:
         layout.name += f" (XOR decoded with key: 0x{xor_key:x})"
 
-    # Collect valid file-backed sections, sorted by offset, deduplicating overlaps.
-    # SHT_NOBITS sections (.bss, .noptrbss) have no file content; skip them.
-    file_sections: List[Tuple[int, int, str]] = []  # (offset, size, name)
-    try:
-        for section in elf.iter_sections():
-            if section["sh_size"] == 0:
-                continue
-            if section["sh_type"] == "SHT_NOBITS":
-                continue
-
-            name = section.name
-            offset = section["sh_offset"]
-            size = section["sh_size"]
-
-            if offset >= slice.range.length:
-                logger.warning("section %s out of range", name)
-                continue
-
-            if offset + size > slice.range.length:
-                size_orig = size
-                size = slice.range.length - offset
-                logger.warning(
-                    "section size %s out of range, truncating from 0x%x to 0x%x bytes", name, size_orig, size
-                )
-
-            file_sections.append((offset, size, name))
-    except Exception as e:
-        logger.warning("failed to parse ELF sections: %s", e)
-
     # Sort by offset, then skip any section that overlaps a previously added section.
-    file_sections.sort(key=lambda t: t[0])
     cursor = 0
-    for offset, size, name in file_sections:
+    for offset, size, name, _is_exec in file_sections:
         if offset < cursor:
             logger.debug("section %s overlaps previous section, skipping", name)
             continue

--- a/floss/qs/main.py
+++ b/floss/qs/main.py
@@ -1267,32 +1267,29 @@ def compute_elf_layout(slice_: Slice, xor_key: int | None) -> Layout:
     # SHT_NOBITS sections (.bss, .noptrbss) have no file content; skip them.
     # Also track executable sections (SHF_EXECINSTR) for #code tagging.
     file_sections: List[Tuple[int, int, str, bool]] = []  # (offset, size, name, is_exec)
-    try:
-        for section in elf.iter_sections():
-            if section["sh_size"] == 0:
-                continue
-            if section["sh_type"] == "SHT_NOBITS":
-                continue
+    for section in elf.iter_sections():
+        if section["sh_size"] == 0:
+            continue
+        if section["sh_type"] == "SHT_NOBITS":
+            continue
 
-            name = section.name
-            offset = section["sh_offset"]
-            size = section["sh_size"]
-            is_exec = bool(section["sh_flags"] & SH_FLAGS.SHF_EXECINSTR)
+        name = section.name
+        offset = section["sh_offset"]
+        size = section["sh_size"]
+        is_exec = bool(section["sh_flags"] & SH_FLAGS.SHF_EXECINSTR)
 
-            if offset >= slice_.range.length:
-                logger.warning("section %s out of range", name)
-                continue
+        if offset >= slice_.range.length:
+            logger.warning("section %s out of range", name)
+            continue
 
-            if offset + size > slice_.range.length:
-                size_orig = size
-                size = slice_.range.length - offset
-                logger.warning(
-                    "section size %s out of range, truncating from 0x%x to 0x%x bytes", name, size_orig, size
-                )
+        if offset + size > slice_.range.length:
+            size_orig = size
+            size = slice_.range.length - offset
+            logger.warning(
+                "section size %s out of range, truncating from 0x%x to 0x%x bytes", name, size_orig, size
+            )
 
-            file_sections.append((offset, size, name, is_exec))
-    except ELFError as e:
-        logger.warning("failed to parse ELF sections: %s", e)
+        file_sections.append((offset, size, name, is_exec))
 
     # Build code_offsets from executable sections before constructing the layout.
     file_sections.sort(key=lambda t: t[0])

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -123,7 +123,8 @@ qs = [
     "colorama==0.4.6",
     "machofile==2026.2.4",
     "msgspec==0.14.2",
-    "python-lancelot==0.8.10",
+    "python-lancelot==0.9.7",
+    "pyelftools==0.31",
 ]
 dev = [
     "pre-commit==4.5.1",

--- a/tests/test_qs_code_ranges.py
+++ b/tests/test_qs_code_ranges.py
@@ -71,7 +71,7 @@ def _make_instr(size: int) -> Mock:
     return instr
 
 
-def _make_be2_mocks(base_address: int, bb_instructions: list):
+def _make_be2_mocks(bb_instructions: list):
     """
     Build mock be2 and idx objects.
 
@@ -107,12 +107,11 @@ def test_get_code_ranges_basic(mock_pe):
     # bb2: va 0x401020, size 0x15 -> rva 0x1020, offset 0x2020 -> range (0x2020, 0x2034)
     # bb3: va 0x402000, size 0x20 -> rva 0x2000, offset 0x3000 -> range (0x3000, 0x301F)
     be2, idx = _make_be2_mocks(
-        0x400000,
         [
             [(0x401000, 0x10)],
             [(0x401020, 0x15)],
             [(0x402000, 0x20)],
-        ],
+        ]
     )
 
     slice_ = Slice(buf=b"", range=Range(offset=0, length=0x5000))
@@ -133,12 +132,11 @@ def test_get_code_ranges_basic(mock_pe):
 def test_get_code_ranges_skips_invalid_offset(mock_pe):
     """Test that it skips instructions that fall outside the slice."""
     be2, idx = _make_be2_mocks(
-        0x400000,
         [
             [(0x401000, 0x10)],  # offset 0x2000, fits in slice
             [(0x401020, 0x15)],  # offset 0x2020, outside slice
             [(0x402000, 0x20)],  # offset 0x3000, outside slice
-        ],
+        ]
     )
 
     # Slice only covers through offset 0x2010
@@ -165,12 +163,11 @@ def test_get_code_ranges_handles_pe_error(mock_pe):
     mock_pe.get_offset_from_rva.side_effect = get_offset_from_rva_with_error
 
     be2, idx = _make_be2_mocks(
-        0x400000,
         [
             [(0x401000, 0x10)],
             [(0x401020, 0x15)],
             [(0x402000, 0x20)],
-        ],
+        ]
     )
 
     slice_ = Slice(buf=b"", range=Range(offset=0, length=0x5000))

--- a/tests/test_qs_code_ranges.py
+++ b/tests/test_qs_code_ranges.py
@@ -1,8 +1,7 @@
-from unittest.mock import Mock, MagicMock
+from unittest.mock import Mock, MagicMock, patch
 
 import pefile
 import pytest
-import lancelot
 
 from floss.qs.main import (
     Range,
@@ -66,39 +65,63 @@ def mock_pe():
     return pe
 
 
-@pytest.fixture
-def mock_ws():
-    """Fixture for a mocked lancelot.Workspace object."""
-    ws = MagicMock(spec=lancelot.Workspace)
-    ws.base_address = 0x400000
-
-    # Mock functions and basic blocks
-    func1 = Mock()
-    func2 = Mock()
-    ws.get_functions.return_value = [func1, func2]
-
-    bb1 = Mock(address=0x401000, length=0x10)  # rva: 0x1000, offset: 0x2000
-    bb2 = Mock(address=0x401020, length=0x15)  # rva: 0x1020, offset: 0x2020
-    bb3 = Mock(address=0x402000, length=0x20)  # rva: 0x2000, offset: 0x3000
-
-    # Setup cfg for each function
-    cfg1 = Mock(basic_blocks={bb1.address: bb1, bb2.address: bb2})
-    cfg2 = Mock(basic_blocks={bb3.address: bb3})
-
-    def build_cfg(func):
-        if func == func1:
-            return cfg1
-        return cfg2
-
-    ws.build_cfg.side_effect = build_cfg
-    return ws
+def _make_instr(size: int) -> Mock:
+    instr = Mock()
+    instr.raw_bytes = b"\x90" * size
+    return instr
 
 
-def test_get_code_ranges_basic(mock_ws, mock_pe):
+def _make_be2_mocks(base_address: int, bb_instructions: list):
+    """
+    Build mock be2 and idx objects.
+
+    bb_instructions: list of lists of (va, size) tuples, one sub-list per basic block.
+    """
+    be2 = MagicMock()
+    idx = MagicMock()
+
+    basic_blocks = {}
+    instr_map = {}
+    for bb_i, instrs in enumerate(bb_instructions):
+        bb = Mock()
+        basic_blocks[bb_i] = bb
+        instr_map[id(bb)] = [(i, _make_instr(sz), va) for i, (va, sz) in enumerate(instrs)]
+
+    fg = Mock()
+    fg.basic_block_index = list(range(len(basic_blocks)))
+    be2.flow_graph = [fg]
+    be2.basic_block = basic_blocks
+
+    def _bb_instructions(bb):
+        return iter(instr_map.get(id(bb), []))
+
+    idx.basic_block_instructions.side_effect = _bb_instructions
+
+    return be2, idx
+
+
+def test_get_code_ranges_basic(mock_pe):
     """Test basic extraction of code ranges."""
-    # Slice covers the entire mock file
+    # base_address = 0x400000, rva = va - base
+    # bb1: va 0x401000, size 0x10 -> rva 0x1000, offset 0x2000 -> range (0x2000, 0x200F)
+    # bb2: va 0x401020, size 0x15 -> rva 0x1020, offset 0x2020 -> range (0x2020, 0x2034)
+    # bb3: va 0x402000, size 0x20 -> rva 0x2000, offset 0x3000 -> range (0x3000, 0x301F)
+    be2, idx = _make_be2_mocks(
+        0x400000,
+        [
+            [(0x401000, 0x10)],
+            [(0x401020, 0x15)],
+            [(0x402000, 0x20)],
+        ],
+    )
+
     slice_ = Slice(buf=b"", range=Range(offset=0, length=0x5000))
-    ranges = _get_code_ranges(mock_ws, mock_pe, slice_)
+
+    with patch("floss.qs.main.lancelot") as mock_lancelot:
+        mock_lancelot.be2utils.find_be2_base_address.return_value = 0x400000
+        mock_lancelot.be2utils.BinExport2Index.return_value = idx
+
+        ranges = _get_code_ranges(be2, mock_pe, slice_)
 
     assert ranges == [
         (0x2000, 0x200F),  # bb1: offset 0x2000, size 0x10
@@ -107,20 +130,33 @@ def test_get_code_ranges_basic(mock_ws, mock_pe):
     ]
 
 
-def test_get_code_ranges_skips_invalid_offset(mock_ws, mock_pe):
-    """Test that it skips basic blocks that fall outside the slice."""
-    # Slice is small and only covers the first basic block
+def test_get_code_ranges_skips_invalid_offset(mock_pe):
+    """Test that it skips instructions that fall outside the slice."""
+    be2, idx = _make_be2_mocks(
+        0x400000,
+        [
+            [(0x401000, 0x10)],  # offset 0x2000, fits in slice
+            [(0x401020, 0x15)],  # offset 0x2020, outside slice
+            [(0x402000, 0x20)],  # offset 0x3000, outside slice
+        ],
+    )
+
+    # Slice only covers through offset 0x2010
     slice_ = Slice(buf=b"", range=Range(offset=0, length=0x2010))
-    ranges = _get_code_ranges(mock_ws, mock_pe, slice_)
+
+    with patch("floss.qs.main.lancelot") as mock_lancelot:
+        mock_lancelot.be2utils.find_be2_base_address.return_value = 0x400000
+        mock_lancelot.be2utils.BinExport2Index.return_value = idx
+
+        ranges = _get_code_ranges(be2, mock_pe, slice_)
 
     # Only bb1 should be included
     assert ranges == [(0x2000, 0x200F)]
 
 
-def test_get_code_ranges_handles_pe_error(mock_ws, mock_pe):
+def test_get_code_ranges_handles_pe_error(mock_pe):
     """Test that it handles PEFormatError when getting an offset."""
 
-    # Make one of the RVA lookups fail
     def get_offset_from_rva_with_error(rva):
         if rva == 0x1020:  # Corresponds to bb2
             raise pefile.PEFormatError("Test Error")
@@ -128,10 +164,24 @@ def test_get_code_ranges_handles_pe_error(mock_ws, mock_pe):
 
     mock_pe.get_offset_from_rva.side_effect = get_offset_from_rva_with_error
 
-    slice_ = Slice(buf=b"", range=Range(offset=0, length=0x5000))
-    ranges = _get_code_ranges(mock_ws, mock_pe, slice_)
+    be2, idx = _make_be2_mocks(
+        0x400000,
+        [
+            [(0x401000, 0x10)],
+            [(0x401020, 0x15)],
+            [(0x402000, 0x20)],
+        ],
+    )
 
-    # bb2 should be skipped
+    slice_ = Slice(buf=b"", range=Range(offset=0, length=0x5000))
+
+    with patch("floss.qs.main.lancelot") as mock_lancelot:
+        mock_lancelot.be2utils.find_be2_base_address.return_value = 0x400000
+        mock_lancelot.be2utils.BinExport2Index.return_value = idx
+
+        ranges = _get_code_ranges(be2, mock_pe, slice_)
+
+    # bb2 should be skipped due to PEFormatError
     assert ranges == [
         (0x2000, 0x200F),
         (0x3000, 0x301F),

--- a/tests/test_qs_code_ranges.py
+++ b/tests/test_qs_code_ranges.py
@@ -1,4 +1,4 @@
-from unittest.mock import Mock, MagicMock, patch
+from unittest.mock import Mock, MagicMock
 
 import pefile
 import pytest
@@ -116,11 +116,7 @@ def test_get_code_ranges_basic(mock_pe):
 
     slice_ = Slice(buf=b"", range=Range(offset=0, length=0x5000))
 
-    with patch("floss.qs.main.lancelot") as mock_lancelot:
-        mock_lancelot.be2utils.find_be2_base_address.return_value = 0x400000
-        mock_lancelot.be2utils.BinExport2Index.return_value = idx
-
-        ranges = _get_code_ranges(be2, mock_pe, slice_)
+    ranges = _get_code_ranges(be2, idx, 0x400000, mock_pe, slice_)
 
     assert ranges == [
         (0x2000, 0x200F),  # bb1: offset 0x2000, size 0x10
@@ -142,11 +138,7 @@ def test_get_code_ranges_skips_invalid_offset(mock_pe):
     # Slice only covers through offset 0x2010
     slice_ = Slice(buf=b"", range=Range(offset=0, length=0x2010))
 
-    with patch("floss.qs.main.lancelot") as mock_lancelot:
-        mock_lancelot.be2utils.find_be2_base_address.return_value = 0x400000
-        mock_lancelot.be2utils.BinExport2Index.return_value = idx
-
-        ranges = _get_code_ranges(be2, mock_pe, slice_)
+    ranges = _get_code_ranges(be2, idx, 0x400000, mock_pe, slice_)
 
     # Only bb1 should be included
     assert ranges == [(0x2000, 0x200F)]
@@ -172,11 +164,7 @@ def test_get_code_ranges_handles_pe_error(mock_pe):
 
     slice_ = Slice(buf=b"", range=Range(offset=0, length=0x5000))
 
-    with patch("floss.qs.main.lancelot") as mock_lancelot:
-        mock_lancelot.be2utils.find_be2_base_address.return_value = 0x400000
-        mock_lancelot.be2utils.BinExport2Index.return_value = idx
-
-        ranges = _get_code_ranges(be2, mock_pe, slice_)
+    ranges = _get_code_ranges(be2, idx, 0x400000, mock_pe, slice_)
 
     # bb2 should be skipped due to PEFormatError
     assert ranges == [

--- a/tests/test_qs_elf.py
+++ b/tests/test_qs_elf.py
@@ -50,7 +50,9 @@ def test_elf_structures_present():
 
 def test_elf_code_and_reloc_offsets():
     layout = _load_layout(X86_64_PIE)
-    assert (0x10A0, 0x1265) in layout.code_offsets.ranges          # .text exec range
+    # .text (offset 0x10a0, size 0x1c5) is fully covered by code ranges;
+    # it merges with adjacent exec sections (.plt etc.) so we check coverage, not exact range
+    assert layout.code_offsets.overlaps(0x10A0, 0x10A0 + 0x1C5 - 1)
     assert (0x568, 0x66F) in layout.relocation_offsets.ranges      # .rela.dyn + .rela.plt merged
 
 

--- a/tests/test_qs_elf.py
+++ b/tests/test_qs_elf.py
@@ -1,6 +1,6 @@
 from pathlib import Path
 
-from floss.qs.main import ELFLayout, Slice, compute_layout
+from floss.qs.main import Slice, ELFLayout, compute_layout
 
 CD = Path(__file__).resolve().parent
 ELF_DIR = CD / "data" / "elf"
@@ -24,6 +24,10 @@ def test_elf_layout():
     assert isinstance(layout, ELFLayout)
     assert layout.name == "elf"
     assert layout.children
+    text_sections = [c for c in layout.children if c.name == ".text"]
+    assert len(text_sections) == 1
+    assert text_sections[0].offset == 0x10A0
+    assert text_sections[0].slice.range.length == 0x1C5
 
 
 def test_elf_section_names():
@@ -37,13 +41,17 @@ def test_elf_section_names():
 
 def test_elf_structures_present():
     layout = _load_layout(X86_64_PIE)
-    assert layout.structures_by_address
+    assert layout.structures_by_address[0x0].name == "elf header"
+    assert layout.structures_by_address[0x40].name == "program header"
+    assert layout.structures_by_address[0x39D0].name == "section header"
+    assert layout.structures_by_address[0x3C8].name == "symbol table"  # .dynsym
+    assert layout.structures_by_address[0x4A0].name == "string table"  # .dynstr
 
 
 def test_elf_code_and_reloc_offsets():
     layout = _load_layout(X86_64_PIE)
-    assert layout.code_offsets.ranges
-    assert layout.relocation_offsets.ranges
+    assert (0x10A0, 0x1265) in layout.code_offsets.ranges          # .text exec range
+    assert (0x568, 0x66F) in layout.relocation_offsets.ranges      # .rela.dyn + .rela.plt merged
 
 
 def test_arm64_so_android_note_section():

--- a/tests/test_qs_elf.py
+++ b/tests/test_qs_elf.py
@@ -1,0 +1,60 @@
+from pathlib import Path
+
+from floss.qs.main import ELFLayout, Slice, compute_layout
+
+CD = Path(__file__).resolve().parent
+ELF_DIR = CD / "data" / "elf"
+
+# x86-64 PIE, dynamically linked, not stripped
+X86_64_PIE = "055da8e6ccfe5a9380231ea04b850e18.elf"
+# ARM64 shared object, dynamically linked, stripped, Android linker
+ARM64_SO = "687e79cde5b0ced75ac229465835054931f9ec438816f2827a8be5f3bd474929.elf"
+# ARM64 PIE, dynamically linked, stripped
+ARM64_LS = "ls"
+
+
+def _load_layout(name: str):
+    path = ELF_DIR / name
+    data = path.read_bytes()
+    return compute_layout(Slice.from_bytes(data))
+
+
+def test_elf_layout():
+    layout = _load_layout(X86_64_PIE)
+    assert isinstance(layout, ELFLayout)
+    assert layout.name == "elf"
+    assert layout.children
+
+
+def test_elf_section_names():
+    # x86-64, not stripped: executable code section, dynamic string table, and symbol table all present
+    layout = _load_layout(X86_64_PIE)
+    names = {child.name for child in layout.children}
+    assert ".text" in names
+    assert ".dynstr" in names
+    assert ".symtab" in names
+
+
+def test_elf_structures_present():
+    layout = _load_layout(X86_64_PIE)
+    assert layout.structures_by_address
+
+
+def test_elf_code_and_reloc_offsets():
+    layout = _load_layout(X86_64_PIE)
+    assert layout.code_offsets.ranges
+    assert layout.relocation_offsets.ranges
+
+
+def test_arm64_so_android_note_section():
+    # Android shared object has an Android-specific note section absent from standard Linux ELFs
+    layout = _load_layout(ARM64_SO)
+    names = {child.name for child in layout.children}
+    assert ".note.android.ident" in names
+
+
+def test_arm64_ls_stripped():
+    # stripped binary has no symbol table
+    layout = _load_layout(ARM64_LS)
+    names = {child.name for child in layout.children}
+    assert ".symtab" not in names

--- a/tests/test_qs_elf.py
+++ b/tests/test_qs_elf.py
@@ -5,7 +5,7 @@ from floss.qs.main import Slice, ELFLayout, compute_layout
 CD = Path(__file__).resolve().parent
 ELF_DIR = CD / "data" / "elf"
 
-# x86-64 PIE, dynamically linked, not stripped
+# x86-64 Position Independent Executable (PIE), dynamically linked, not stripped
 X86_64_PIE = "055da8e6ccfe5a9380231ea04b850e18.elf"
 # ARM64 shared object, dynamically linked, stripped, Android linker
 ARM64_SO = "687e79cde5b0ced75ac229465835054931f9ec438816f2827a8be5f3bd474929.elf"


### PR DESCRIPTION
Extends QS to parse and analyze ELF executables natively, the same way it already handles PE and Mach-O files.

Closes #785 

## Summary

- Parses ELF section headers to build a structured layout of the binary
- Skips SHT_NOBITS sections (`.bss`, etc.) that have no file-backed content
- Deduplicates overlapping sections to avoid scanning the same bytes twice
- Tags strings found inside relocation sections as `#reloc`
- Tags strings decoded via XOR with `#decoded`
- Upgrades the lancelot integration from the old `Workspace` API to `BinExport2`-based instruction iteration (affects PE analysis too)

## Screenshots

Running on [`test-decode-base64`](https://github.com/mandiant/flare-floss-testfiles/blob/4c3f4bb64d1132ce98f834220986237d22a52c04/src/decode-base64/bin/test-decode-base64):

<img width="1489" height="846" alt="image" src="https://github.com/user-attachments/assets/408758a4-c29e-483c-9517-738b37c13bac" />

<img width="1512" height="884" alt="image" src="https://github.com/user-attachments/assets/a44e895d-2994-4542-9927-8994f8ccb3b0" />

## TODOs 

- [x] ~Code range detection (`#code` tagging) is not implemented, `code_offsets` is always empty, so ELF strings are never tagged as code-region strings even if they fall inside `.text`~ Added `#code` tagging support.
- [x] The lancelot `BinExport2` change is a breaking API migration (`lancelot==0.9.7`), not just an ELF addition. Existing PE analysis behavior changes at the instruction granularity level (was basic-block-length, now per-instruction `raw_bytes`). See willi's comment here https://github.com/mandiant/flare-floss/issues/785#issuecomment-3286535023 for why it was needed.
- [x] ~ELF structure marking is minimal for now, only `.shstrtab` is registered as a named structure; other metadata sections (`.dynsym`, `.dynamic`, etc.) are not tracked.~ Now these are populated into structures as `string table`, `section header`, etc.

Credits to @FredCoast for his work on the lancelot migration and initial ELF support.