### PR TITLE
Catch lancelot panics during PE layout computation

### DIFF
--- a/floss/qs/main.py
+++ b/floss/qs/main.py
@@ -1433,6 +1433,10 @@ def compute_pe_layout(slice: Slice, xor_key: int | None) -> Layout:
             be2 = lancelot.get_binexport2_from_bytes(data)
         except ValueError as e:
             logger.warning("lancelot failed to load workspace: %s", e)
+        except BaseException as e:
+            if isinstance(e, (KeyboardInterrupt, SystemExit)):
+                raise
+            logger.warning("lancelot failed critically (panic): %s", e)
 
     # contains the file offsets of bytes that are part of recognized instructions.
     code_offsets = OffsetRanges()


### PR DESCRIPTION
Lancelot (Rust library) can panic on certain malformed or complex PE files, raising pyo3_runtime.PanicException (which inherits from BaseException). Catch BaseException (excluding KeyboardInterrupt/SystemExit) to prevent crashing the entire run.