### PR TITLE
fix(workflow): pin dependencies and fix versioning

### DIFF
--- a/.github/workflows/build-oss-db.yml
+++ b/.github/workflows/build-oss-db.yml
@@ -47,7 +47,7 @@ jobs:
           python-version: '3.12'
 
       - name: Set up Rust
-        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+        uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
 
       - name: Build jh
         run: |

--- a/.github/workflows/build-qs.yml
+++ b/.github/workflows/build-qs.yml
@@ -43,7 +43,7 @@ jobs:
         run: pip install -e .[qs]
       - name: Build standalone executable
         run: pyinstaller .github/pyinstaller/qs.spec
-      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.4
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: ${{ matrix.asset_name }}
           path: dist/${{ matrix.artifact_name }}
@@ -111,7 +111,7 @@ jobs:
       - name: Zip ${{ matrix.artifact_name }} into ${{ env.zip_name }}
         run: zip ${{ env.zip_name }} ${{ matrix.artifact_name }}
       - name: Upload ${{ env.zip_name }} to GH Release
-        uses: svenstaro/upload-release-action@81c65b7cd4de9b2570615ce3aad67a41de5b1a13 # v2.11.2
+        uses: svenstaro/upload-release-action@81c65b7cd4de9b2570615ce3aad67a41de5b1a13 # 2.11.2
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
           file: ${{ env.zip_name }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -114,7 +114,7 @@ jobs:
       - name: Zip ${{ matrix.artifact_name }} into ${{ env.zip_name }}
         run: zip ${{ env.zip_name }} ${{ matrix.artifact_name }}
       - name: Upload ${{ env.zip_name }} to GH Release
-        uses: svenstaro/upload-release-action@04733e069f2d7f7f0b4aebc4fbdbce8613b03ccd # v2.9.0
+        uses: svenstaro/upload-release-action@04733e069f2d7f7f0b4aebc4fbdbce8613b03ccd # 2.9.0
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
           file: ${{ env.zip_name }}


### PR DESCRIPTION
Fixes pinact CI issues as mentioned in https://github.com/mandiant/flare-floss/pull/1328#issuecomment-4929346163

- The workflow `dtolnay/rust-toolchain` gets a new SHA for `v1` tag, comment `# stable` → `# v1`
- For`actions/upload-artifact`, the comment `# v4.6.4` → `# v4.6.2` (SHA was already correct for 4.6.2)
- For both `build-qs.yml:114` and `build.yml:117` respectively
   - `svenstaro/upload-release-action`: comment `# v2.11.2` → `# 2.11.2`
   - `svenstaro/upload-release-action`: comment `# v2.9.0` → `# 2.9.0`

